### PR TITLE
ci(release): update Homebrew formula action to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,9 +161,9 @@ jobs:
       - name: Extract version
         id: extract-version
         run: |
-          echo "tag-name=${GITHUB_REF#refs/tags/}" >> ${GITHUB_OUTPUT}
+          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-      - uses: mislav/bump-homebrew-formula-action@v3
+      - uses: mislav/bump-homebrew-formula-action@v4
         if: ${{ !contains(github.ref, '-') }} # skip prereleases
         with:
           formula-name: tmux-copyrat


### PR DESCRIPTION
Updates the GitHub Actions workflow to use bump-homebrew-formula-action v4 and fixes GITHUB_OUTPUT quoting.

This aligns with the latest version of the action and ensures proper handling of output variables in newer GitHub Actions versions.