### PR TITLE
ci: harden GitHub Actions per zizmor and poutine audits

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,53 @@
+# Reusable workflow: dependency audit via cargo-deny and cargo-pants.
+
+name: Cargo Audit
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  cargo-audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Rust install
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Cache crates from crates.io
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-stable-audit-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: cargo deny check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(gh api repos/EmbarkStudios/cargo-deny/releases/latest --jq '.tag_name')
+          curl -sSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${VERSION}/cargo-deny-${VERSION}-x86_64-unknown-linux-musl.tar.gz" | \
+            tar zx --no-anchored cargo-deny --strip-components=1
+          chmod +x cargo-deny
+          mv cargo-deny ~/.cargo/bin/
+          cargo deny check
+
+      - name: cargo pants
+        run: |
+          cargo install --locked cargo-pants || true
+          cargo pants

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -1,0 +1,48 @@
+# Reusable workflow: CI/CD supply chain security audits.
+
+name: CI Security
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+
+  poutine:
+    name: Poutine
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run poutine
+        uses: boostsecurityio/poutine-action@a563bfa02c3e093e52fb82f53eab0d3a0f348c34 # main (2026-04-07)
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          sarif_file: results.sarif
+          category: poutine

--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -7,29 +7,35 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   test:
     name: Quality checks & tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         rust: [stable]
     steps:
       - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           # fetch-depth: ${{ github.event.pull_request.commits }}
+          persist-credentials: false
 
       - name: Cache crates from crates.io
-        uses: actions/cache@v5
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         continue-on-error: false
         with:
           path: |
@@ -51,43 +57,13 @@ jobs:
       - name: Quality - convco check
         run: |
           git show-ref
+          echo Commit message: "$(git log -1 --pretty=%B)"
           curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
           unzip convco-ubuntu.zip
           chmod +x convco
           ./convco --version
           ./convco check -c .convco
           rm convco
-
-      - name: Quality - cargo deny check
-        run: |
-          VERSION=$(curl -s https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/latest | jq -r '.tag_name')
-          curl -sSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${VERSION}/cargo-deny-${VERSION}-x86_64-unknown-linux-musl.tar.gz" | \
-            tar zx --no-anchored cargo-deny --strip-components=1
-          chmod +x cargo-deny
-          mv cargo-deny ~/.cargo/bin/
-          cargo deny check
-
-      - name: Quality - cargo outdated
-        if: github.event_name == 'pull_request'
-        timeout-minutes: 20
-        run: |
-          VERSION=$(curl -s https://api.github.com/repos/kbknapp/cargo-outdated/releases/latest | jq -r '.tag_name')
-          curl -sSfL "https://github.com/kbknapp/cargo-outdated/releases/download/${VERSION}/cargo-outdated-${VERSION#v}-x86_64-unknown-linux-musl.tar.gz" | \
-            tar zx
-          chmod +x cargo-outdated
-          mv cargo-outdated ~/.cargo/bin/
-          rm -rf ~/.cargo/advisory-db
-          cargo outdated --exit-code 1
-
-      # - name: Quality - cargo udeps (needs nightly)
-      #   run: |
-      #     cargo install --locked cargo-udeps || true
-      #     cargo udeps
-
-      - name: Quality - cargo pants
-        run: |
-          cargo install --locked cargo-pants || true
-          cargo pants
 
       - name: Build (dev)
         run: cargo build --all-features
@@ -97,3 +73,45 @@ jobs:
 
       - name: Test
         run: ./ci/test_full.sh
+
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      cargo_lock: ${{ steps.filter.outputs.cargo_lock }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            cargo_lock:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            workflows:
+              - '.github/workflows/**'
+              - '.github/actions/**'
+              - '.poutine.yml'
+              - '.github/zizmor.yml'
+              - 'renovate.json'
+
+  cargo-audit:
+    needs: changes
+    if: needs.changes.outputs.cargo_lock == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/cargo-audit.yml
+
+  ci-security:
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true'
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    uses: ./.github/workflows/ci-security.yml

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -6,26 +6,32 @@ on:
     branches:
       - staging
 
+permissions: {}
+
 jobs:
   test-versions:
     name: Tests on Linux
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         rust: [1.85.0, beta, nightly]
 
     steps:
       - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Cache crates from crates.io
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         continue-on-error: false
         with:
           path: |
@@ -55,7 +61,9 @@ jobs:
 
   test-other-platforms:
     name: Tests on
-    runs-on: ${{ matrix.os }}
+    runs-on: '${{ matrix.os }}'
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -73,17 +81,19 @@ jobs:
             toolchain: stable
     steps:
       - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.toolchain }}
           targets: ${{ matrix.target }}
           components: rustfmt, clippy
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Cache crates from crates.io
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         continue-on-error: false
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,17 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+permissions: {}
 
 jobs:
   prepare-artifacts:
     name: Prepare release artifacts
     # if: github.ref == 'refs/heads/main'
-    runs-on: ${{ matrix.os }}
+    runs-on: '${{ matrix.os }}'
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -39,7 +43,7 @@ jobs:
             #   archive_ext: zip
     steps:
       - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
@@ -49,53 +53,62 @@ jobs:
         if: contains(matrix.target, '-musl')
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
-      - name: checkout
-        uses: actions/checkout@v6
-
-      - name: Cache crates from crates.io
-        uses: actions/cache@v5
-        continue-on-error: false
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Build Release
-        run: cargo build --release --target ${{ matrix.target }}
+        env:
+          TARGET: ${{ matrix.target }}
+        run: cargo build --release --target "${TARGET}"
 
       - name: Compress to zip (macOS)
         if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel' }}
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          TARGET: ${{ matrix.target }}
+          ARCHIVE_EXT: ${{ matrix.archive_ext }}
         run: |
-          cp target/${{ matrix.target }}/release/${{ github.event.repository.name }} .
-          zip -A ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }} ${{ github.event.repository.name }}
+          cp "target/${TARGET}/release/${REPO_NAME}" .
+          zip -A "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
 
       - name: Compress to zip (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          TARGET: ${{ matrix.target }}
+          ARCHIVE_EXT: ${{ matrix.archive_ext }}
+          SUFFIX: ${{ matrix.suffix }}
         run: |
-          Copy-Item target/${{ matrix.target }}/release/${{ github.event.repository.name }}${{ matrix.suffix }} .
-          Compress-Archive ${{ github.event.repository.name }}${{ matrix.suffix }} ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
+          Copy-Item "target/${env:TARGET}/release/${env:REPO_NAME}${env:SUFFIX}" .
+          Compress-Archive "${env:REPO_NAME}${env:SUFFIX}" "${env:REPO_NAME}-${env:TARGET}.${env:ARCHIVE_EXT}"
 
       - name: Compress to tar.xz (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          TARGET: ${{ matrix.target }}
+          ARCHIVE_EXT: ${{ matrix.archive_ext }}
         run: |
-          cp target/${{ matrix.target }}/release/${{ github.event.repository.name }} .
-          tar Jcf ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }} ${{ github.event.repository.name }}
+          cp "target/${TARGET}/release/${REPO_NAME}" .
+          tar Jcf "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
 
       - name: List files
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
           ls -alF .
-          ls -alF target/${{ matrix.target }}/release/
+          ls -alF "target/${TARGET}/release/"
         shell: bash
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
           path: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
+          retention-days: 1
 
   release:
     name: Create a GitHub Release
@@ -103,19 +116,22 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     needs:
       - prepare-artifacts
     steps:
-      - name: checkout
-        uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # convco needs all history to create the changelog
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Extract version
         id: extract-version
         run: |
-          echo "tag-name=${GITHUB_REF#refs/tags/}" >> ${GITHUB_OUTPUT}
+          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
       - name: Download convco
         run: |
@@ -129,46 +145,64 @@ jobs:
           ./convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
           rm convco convco-ubuntu.zip
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.event.repository.name }}-x86_64-unknown-linux-musl.tar.xz
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.event.repository.name }}-aarch64-unknown-linux-musl.tar.xz
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.event.repository.name }}-aarch64-apple-darwin.zip
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.event.repository.name }}-x86_64-apple-darwin.zip
-      # - uses: actions/download-artifact@v8
-      #   with:
-      #     name: ${{ github.event.repository.name }}-x86_64-pc-windows-msvc.zip
 
-      - uses: ncipollo/release-action@v1
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release create "${TAG_NAME}" \
+            --title "${TAG_NAME}" \
+            --notes-file CHANGELOG.md \
+            ./*.zip ./*.tar.xz
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          artifacts: '*.zip,*.tar.xz'
-          bodyFile: 'CHANGELOG.md'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          subject-path: '*.zip,*.tar.xz'
 
   homebrew:
     name: Bump Homebrew formula
     # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
     needs:
       - release
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: graelo
+          repositories: homebrew-tap
+
       - name: Extract version
         id: extract-version
         run: |
           echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-      - uses: mislav/bump-homebrew-formula-action@v4
-        if: ${{ !contains(github.ref, '-') }} # skip prereleases
+      - uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
+        if: '!contains(github.ref, ''-'')' # skip prereleases
         with:
           formula-name: tmux-copyrat
           homebrew-tap: graelo/homebrew-tap
-          # base-branch: main
+          push-to: graelo/homebrew-tap
           create-pullrequest: true
           download-url: https://github.com/graelo/tmux-copyrat/archive/refs/tags/${{ steps.extract-version.outputs.tag-name }}.tar.gz
           commit-message: |
@@ -176,4 +210,4 @@ jobs:
 
             Created by https://github.com/mislav/bump-homebrew-formula-action
         env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+          COMMITTER_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,41 @@
+# Runs Renovate to check for dependency updates.
+# Triggers weekly on Friday afternoons, or manually via workflow_dispatch.
+
+name: Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 16 * * 5' # every Friday at 16:00 UTC
+
+permissions: {}
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    environment: renovate
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@b67590ea780158ccd13192c22a3655a5231f869d # v46.1.8
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          configurationFile: renovate.json

--- a/.github/workflows/supply-chain-schedule.yml
+++ b/.github/workflows/supply-chain-schedule.yml
@@ -1,0 +1,24 @@
+# Scheduled supply chain audits: dependency vulnerabilities and CI security.
+
+name: Supply Chain Audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 16 * * 2' # Tuesday at 16:00 UTC
+    - cron: '0 16 * * 5' # Friday at 16:00 UTC
+
+permissions: {}
+
+jobs:
+  cargo-audit:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/cargo-audit.yml
+
+  ci-security:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    uses: ./.github/workflows/ci-security.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+rules:
+  # TODO: replace with action-name-based ignore once available
+  # (zizmorcore/zizmor#1086). All occurrences are dtolnay/rust-toolchain,
+  # which is intentional for multi-version matrix builds.
+  superfluous-actions:
+    ignore:
+      - cargo-audit.yml
+      - essentials.yml
+      - large-scope.yml
+      - release.yml

--- a/.poutine.yml
+++ b/.poutine.yml
@@ -1,0 +1,11 @@
+skip:
+  # Well-known actions from trusted maintainers without GitHub's marketplace
+  # "verified creator" badge.
+  - rule: github_action_from_unverified_creator_used
+    purl:
+      - pkg:githubactions/dtolnay/rust-toolchain
+      - pkg:githubactions/dorny/paths-filter
+      - pkg:githubactions/zizmorcore/zizmor-action
+      - pkg:githubactions/boostsecurityio/poutine-action
+      - pkg:githubactions/mislav/bump-homebrew-formula-action
+      - pkg:githubactions/renovatebot/github-action

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "gitAuthor": "graelo-ci-bot[bot] <274240725+graelo-ci-bot[bot]@users.noreply.github.com>",
+  "labels": [
+    "dependencies"
+  ],
+  "cargo": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Pin GitHub Actions to commit SHAs for supply chain safety",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true
+    },
+    {
+      "description": "Group all patch updates into one PR",
+      "matchUpdateTypes": "patch",
+      "groupName": "patch updates"
+    },
+    {
+      "description": "Group all minor updates into one PR",
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "groupName": "minor updates"
+    }
+  ],
+  "schedule": [
+    "before 9pm on friday"
+  ]
+}


### PR DESCRIPTION
Pin third-party actions to commit SHAs, scope per-job permissions,
disable persisted git credentials, move ${{ }} interpolations into
env to block template injection, tighten the release tag glob to
semver, drop the build cache from release.yml to avoid cache
poisoning, set short artifact retention, replace ncipollo with
gh release create, and add build provenance attestation.

Move dependency audit (cargo-deny + cargo-pants) and CI security
scans (zizmor + poutine) into reusable workflows, called from
essentials via dorny/paths-filter when Cargo.lock or workflow
files change, and unconditionally on a Tue/Fri schedule.

Switch the homebrew bump and a new Renovate workflow to short-lived
GitHub App tokens via dedicated `release` and `renovate`
environments. Add zizmor.yml, .poutine.yml, and a renovate.json
that pins action digests.

Manual follow-up before merging changes can run end-to-end:

- [ ] create `release` and `renovate` environments in repo settings
      with branch/tag rules and `APP_CLIENT_ID` / `APP_PRIVATE_KEY`
- [ ] confirm the GitHub App is installed on tmux-copyrat and
      homebrew-tap
- [ ] manually trigger the Renovate workflow once before deleting
      the old repo-wide `COMMITTER_TOKEN`