### PR TITLE
chore: bump to edition 2024 and MSRV 1.88

### DIFF
--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        rust: [1.85.0, beta, nightly]
+        rust: [1.88.0, beta, nightly]
 
     steps:
       - name: Rust install

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,15 +63,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -164,9 +164,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -341,12 +341,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "copyrat"
 version = "0.8.5"
-edition = "2021"
+edition = "2024"
+rust-version = "1.88"
 description = "A tmux plugin for copy-pasting within tmux panes."
 documentation = "https://docs.rs/tmux-copyrat"
 readme = "README.md"

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -55,7 +55,7 @@ binary because it sees it's present in the `PATH`.
 
 ## Cargo (build from source)
 
-Requires `rustc 1.85+`.
+Requires `rustc 1.88+`.
 
 ```bash
 cargo install copyrat

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # tmux-copyrat
 
 [![build status](https://github.com/graelo/tmux-copyrat/actions/workflows/essentials.yml/badge.svg)](https://github.com/graelo/tmux-copyrat/actions)
-[![rustc 1.85+](https://img.shields.io/badge/rustc-1.85+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
-[![edition 2021](https://img.shields.io/badge/edition-2021-blue.svg)](https://doc.rust-lang.org/edition-guide/rust-2021/index.html)
+[![rustc 1.88+](https://img.shields.io/badge/rustc-1.88+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![edition 2024](https://img.shields.io/badge/edition-2024-blue.svg)](https://doc.rust-lang.org/edition-guide/rust-2024/index.html)
 [![crate](https://img.shields.io/crates/v/copyrat.svg)](https://crates.io/crates/copyrat)
 [![tmux 3.0+](https://img.shields.io/badge/tmux-3.0+-blue.svg)](https://tmux.github.io)
 

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -5,6 +5,6 @@
 set -ex
 
 ci=$(dirname $0)
-for version in 1.85.0 stable beta nightly; do
+for version in 1.88.0 stable beta nightly; do
     rustup run "$version" "$ci/test_full.sh"
 done

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -3,7 +3,7 @@
 set -e
 
 CRATE=tmux-copyrat
-MSRV=1.85
+MSRV=1.88
 
 get_rust_version() {
   local array=($(rustc --version));

--- a/src/bin/tmux_copyrat.rs
+++ b/src/bin/tmux_copyrat.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 use copyrat::{
+    Result,
     config::extended::{ConfigExt, MainConfig, OutputDestination},
     tmux,
     ui::Selection,
-    Result,
 };
 
 fn main() -> Result<()> {

--- a/src/config/basic.rs
+++ b/src/config/basic.rs
@@ -3,9 +3,10 @@ use std::fmt::Display;
 use clap::{ArgAction, Parser, ValueEnum};
 
 use crate::{
+    Error, Result,
     config::extended::OutputDestination,
     textbuf::{alphabet, regexes},
-    ui, Error, Result,
+    ui,
 };
 
 /// Main configuration, parsed from command line.

--- a/src/config/extended.rs
+++ b/src/config/extended.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use clap::{Args, Parser, ValueEnum};
 
 use super::basic;
-use crate::{textbuf::alphabet, tmux, ui, Error, Result};
+use crate::{Error, Result, textbuf::alphabet, tmux, ui};
 
 #[derive(Parser, Debug)]
 #[clap(author, about, version)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! same functionality. For this Rust implementation, I got inspired by
 //! [tmux-thumbs], and I even borrowed some parts of his regex tests.
 //!
-//! Version requirement: _rustc 1.85+_
+//! Version requirement: _rustc 1.88+_
 //!
 //! ## Demo
 //!

--- a/src/textbuf/alphabet.rs
+++ b/src/textbuf/alphabet.rs
@@ -111,14 +111,14 @@ impl Alphabet {
             let prefix = lead.pop().unwrap();
 
             // generate characters pairs
-            let gen: Vec<String> = letters
+            let pairs: Vec<String> = letters
                 .iter()
                 .take(n - lead.len() - prev.len())
                 .map(|c| format!("{prefix}{c}"))
                 .collect();
 
-            // Insert gen in front of prev
-            prev.splice(..0, gen);
+            // Insert pairs in front of prev
+            prev.splice(..0, pairs);
         }
 
         // Finalize by concatenating the lead and prev components, filling
@@ -171,7 +171,9 @@ mod tests {
         let hints = alphabet.make_hints(13);
         assert_eq!(
             hints,
-            ["a", "ba", "bb", "bc", "bd", "ca", "cb", "cc", "cd", "da", "db", "dc", "dd"]
+            [
+                "a", "ba", "bb", "bc", "bd", "ca", "cb", "cc", "cd", "da", "db", "dc", "dd"
+            ]
         );
     }
 

--- a/src/textbuf/mod.rs
+++ b/src/textbuf/mod.rs
@@ -94,8 +94,7 @@ mod tests {
 
     #[test]
     fn match_ansi_colors() {
-        let buffer =
-        "path: [32m/var/log/nginx.log[m\npath: [32mtest/log/nginx-2.log:32[mfolder/.nginx@4df2.log";
+        let buffer = "path: [32m/var/log/nginx.log[m\npath: [32mtest/log/nginx-2.log:32[mfolder/.nginx@4df2.log";
         let lines = buffer.split('\n').collect::<Vec<_>>();
         let use_all_patterns = true;
         let named_pat = vec![];
@@ -122,8 +121,7 @@ mod tests {
 
     #[test]
     fn match_paths() {
-        let buffer =
-        "Lorem /tmp/foo/bar_lol, lorem\n Lorem /var/log/boot-strap.log lorem ../log/kern.log lorem";
+        let buffer = "Lorem /tmp/foo/bar_lol, lorem\n Lorem /var/log/boot-strap.log lorem ../log/kern.log lorem";
         let lines = buffer.split('\n').collect::<Vec<_>>();
         let use_all_patterns = true;
         let named_pat = vec![];

--- a/src/textbuf/model.rs
+++ b/src/textbuf/model.rs
@@ -5,7 +5,7 @@ use sequence_trie::SequenceTrie;
 
 use super::alphabet::Alphabet;
 use super::raw_span::RawSpan;
-use super::regexes::{NamedPattern, EXCLUDE_PATTERNS, PATTERNS};
+use super::regexes::{EXCLUDE_PATTERNS, NamedPattern, PATTERNS};
 use super::span::Span;
 
 /// Holds data for the `Ui`.

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -164,7 +164,7 @@ pub fn available_panes() -> Result<Vec<Pane>> {
         "list-panes",
         "-F",
         "#{pane_id}:#{?pane_in_mode,true,false}:#{pane_height}:#{scroll_position}:#{?pane_active,true,false}",
-        ];
+    ];
 
     let output = duct::cmd("tmux", &args).read()?;
 

--- a/src/ui/vc.rs
+++ b/src/ui/vc.rs
@@ -7,8 +7,8 @@ use std::io::Write;
 use termion::{self, color, cursor, event, screen::IntoAlternateScreen, style};
 use unicode_width::UnicodeWidthChar;
 
-use super::colors::UiColors;
 use super::Selection;
+use super::colors::UiColors;
 use super::{HintAlignment, HintStyle};
 use crate::{config::extended::OutputDestination, textbuf};
 
@@ -1525,13 +1525,13 @@ Barcelona https://en.wikipedia.org/wiki/Barcelona -   ";
         let expected_span2_text = {
             let goto11_3 = cursor::Goto(11, 3);
             format!(
-        "{goto11_3}{focus_bg}{focus_fg}https://en.wikipedia.org/wiki/Barcelona{fg_reset}{bg_reset}",
-        goto11_3 = goto11_3,
-        focus_fg = color::Fg(rendering_colors.focused_fg),
-        focus_bg = color::Bg(rendering_colors.focused_bg),
-        fg_reset = color::Fg(color::Reset),
-        bg_reset = color::Bg(color::Reset)
-      )
+                "{goto11_3}{focus_bg}{focus_fg}https://en.wikipedia.org/wiki/Barcelona{fg_reset}{bg_reset}",
+                goto11_3 = goto11_3,
+                focus_fg = color::Fg(rendering_colors.focused_fg),
+                focus_bg = color::Bg(rendering_colors.focused_bg),
+                fg_reset = color::Fg(color::Reset),
+                bg_reset = color::Bg(color::Reset)
+            )
         };
 
         // Because reverse is true, this second span is focused,


### PR DESCRIPTION
Move the crate to Rust edition 2024 and raise MSRV to 1.88. As an
end-user binary (not a library), there's no downside to keeping the
floor close to current stable.

Edition 2024 reserves `gen` as a keyword, so the local of that name
in alphabet.rs is renamed to `pairs`. The rest of the diff is the
new default rustfmt style applied across touched files. Cargo.toml
gains `rust-version = "1.88"` so cargo enforces the floor; the
large-scope matrix, ci/rustup.sh, ci/test_full.sh, README badges,
INSTALLATION.md, and the lib doc header are updated to match.

- [ ] cargo build --all-features
- [ ] cargo clippy --all-targets --all-features -- -D warnings
- [ ] cargo test (49 passed locally)