### PR TITLE
chore: switch markdown lint from markdownlint to rumdl

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,7 +1,0 @@
-MD013:
-  line_length: 80
-  code_block_line_length: 120
-  tables: false
-MD033:
-  allowed_elements:
-    - kbd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,14 @@ repos:
 
       - id: cargo-clippy
         name: cargo clippy
-        entry: cargo clippy --all-targets --all-features -- -D warnings
+        entry: cargo +nightly clippy --all-targets --all-features -- -D warnings
         language: system
         types: [rust]
+        pass_filenames: false
+
+      - id: rumdl
+        name: rumdl check
+        entry: rumdl check
+        language: system
+        types: [markdown]
         pass_filenames: false

--- a/rumdl.toml
+++ b/rumdl.toml
@@ -1,0 +1,22 @@
+# See the lints at https://github.com/rvben/rumdl/tree/main/docs
+[global]
+flavor = "mkdocs"
+disable = [
+  "MD007",  # prefer the flavor over MD007
+  "MD046",  # allow code blocks to be indented and fenced
+]
+
+[code-block-tools]
+enabled = true
+
+[code-block-tools.languages]
+python = { lint = ["ruff:check"], format = ["ruff:format"] }
+
+[MD013]
+line-length = 80
+code-blocks = false
+tables = false
+reflow = true
+
+[MD033]
+allowed-elements = ["kbd"]


### PR DESCRIPTION
Replace markdownlint with rumdl, matching the setup already used in
tmux-backup. rumdl is a Rust-native linter with a faster check loop
and built-in autofix; the new `rumdl.toml` keeps the same intent as
the old `.markdownlint.yaml` (80-col MD013 with `reflow = true`,
`<kbd>` allowed under MD033, mkdocs flavor for MD007/MD046 sanity).

Pre-commit gains a `rumdl check` hook so markdown drift is caught
locally; the cargo-clippy hook is switched to `cargo +nightly clippy`
to match what large-scope CI fires on push to staging (matrix runs
clippy on stable / beta / nightly with `-D warnings`).

Note: rumdl flags one pre-existing finding in CONFIGURATION.md:146
(`#byob---bring-your-own-bindings` is a GitHub-style anchor; mkdocs
slugifies the same heading as `#byob-bring-your-own-bindings`). The
link works on GitHub today and is left untouched.