### PR TITLE
ci: tidy workflow files

### DIFF
--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -52,12 +52,11 @@ jobs:
 
       - name: Quality - cargo clippy
         run: |
-          cargo clippy -- -D warnings
+          cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Quality - convco check
         run: |
           git show-ref
-          echo Commit message: "$(git log -1 --pretty=%B)"
           curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
           unzip convco-ubuntu.zip
           chmod +x convco

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -61,7 +61,7 @@ jobs:
 
   test-other-platforms:
     name: Tests on
-    runs-on: '${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ permissions: {}
 jobs:
   prepare-artifacts:
     name: Prepare release artifacts
-    # if: github.ref == 'refs/heads/main'
     runs-on: '${{ matrix.os }}'
     permissions:
       contents: read
@@ -112,7 +111,6 @@ jobs:
 
   release:
     name: Create a GitHub Release
-    # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -175,7 +173,6 @@ jobs:
 
   homebrew:
     name: Bump Homebrew formula
-    # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: release
     permissions:


### PR DESCRIPTION
Small cleanups across the three workflow files.

Clippy on the essentials job now runs with --all-targets --all-features so
test and bench targets get linted too, and a leftover debug echo of the
commit message is dropped. The large-scope matrix job drops redundant
quoting around ${{ matrix.os }}. The release workflow removes three stale
commented-out `if: github.ref == 'refs/heads/main'` guards that no longer
serve a purpose.