### PR TITLE
chore: bump MSRV to 1.95

### DIFF
--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        rust: [1.88.0, beta, nightly]
+        rust: [1.95.0, beta, nightly]
 
     steps:
       - name: Rust install

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "copyrat"
 version = "0.8.6"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.95"
 description = "A tmux plugin for copy-pasting within tmux panes."
 documentation = "https://docs.rs/tmux-copyrat"
 readme = "README.md"

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -55,7 +55,7 @@ binary because it sees it's present in the `PATH`.
 
 ## Cargo (build from source)
 
-Requires `rustc 1.88+`.
+Requires `rustc 1.95+`.
 
 ```bash
 cargo install copyrat

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tmux-copyrat
 
 [![build status](https://github.com/graelo/tmux-copyrat/actions/workflows/essentials.yml/badge.svg)](https://github.com/graelo/tmux-copyrat/actions)
-[![rustc 1.88+](https://img.shields.io/badge/rustc-1.88+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![rustc 1.95+](https://img.shields.io/badge/rustc-1.95+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![edition 2024](https://img.shields.io/badge/edition-2024-blue.svg)](https://doc.rust-lang.org/edition-guide/rust-2024/index.html)
 [![crate](https://img.shields.io/crates/v/copyrat.svg)](https://crates.io/crates/copyrat)
 [![tmux 3.0+](https://img.shields.io/badge/tmux-3.0+-blue.svg)](https://tmux.github.io)

--- a/src/bin/copyrat.rs
+++ b/src/bin/copyrat.rs
@@ -19,10 +19,8 @@ fn main() {
     let selection: Option<Selection> = run(&lines, &opt);
 
     // Early exit, signaling no selections were found.
-    if selection.is_none() {
+    let Some(Selection { text, .. }) = selection else {
         std::process::exit(1);
-    }
-
-    let Selection { text, .. } = selection.unwrap();
+    };
     println!("{text}");
 }

--- a/src/bin/tmux_copyrat.rs
+++ b/src/bin/tmux_copyrat.rs
@@ -49,35 +49,35 @@ fn run(config: ConfigExt) -> Result<()> {
     // Finally copy selection to the output destination (tmux buffer or
     // clipboard), and paste it to the active buffer if it was uppercased.
 
-    match selection {
-        None => return Ok(()),
-        Some(Selection {
-            text,
-            uppercased,
-            output_destination,
-        }) => {
-            if uppercased {
-                if active_pane.is_copy_mode {
-                    // break out of copy mode
-                    duct::cmd!("tmux", "copy-mode", "-t", active_pane.id.as_str(), "-q").run()?;
-                }
-                duct::cmd!("tmux", "send-keys", "-t", active_pane.id.as_str(), &text).run()?;
-            }
+    let Some(Selection {
+        text,
+        uppercased,
+        output_destination,
+    }) = selection
+    else {
+        return Ok(());
+    };
 
-            match output_destination {
-                OutputDestination::Tmux => {
-                    duct::cmd!("tmux", "set-buffer", &text).run()?;
-                }
-                OutputDestination::Clipboard => {
-                    let mut parts = config.clipboard_exe.split_whitespace();
-                    let program = parts.next().expect("clipboard-exe must not be empty");
-                    let args: Vec<&str> = parts.collect();
+    if uppercased {
+        if active_pane.is_copy_mode {
+            // break out of copy mode
+            duct::cmd!("tmux", "copy-mode", "-t", active_pane.id.as_str(), "-q").run()?;
+        }
+        duct::cmd!("tmux", "send-keys", "-t", active_pane.id.as_str(), &text).run()?;
+    }
 
-                    duct::cmd!("echo", "-n", &text)
-                        .pipe(duct::cmd(program, &args))
-                        .read()?;
-                }
-            }
+    match output_destination {
+        OutputDestination::Tmux => {
+            duct::cmd!("tmux", "set-buffer", &text).run()?;
+        }
+        OutputDestination::Clipboard => {
+            let mut parts = config.clipboard_exe.split_whitespace();
+            let program = parts.next().expect("clipboard-exe must not be empty");
+            let args: Vec<&str> = parts.collect();
+
+            duct::cmd!("echo", "-n", &text)
+                .pipe(duct::cmd(program, &args))
+                .read()?;
         }
     }
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -196,13 +196,11 @@ pub fn get_options(prefix: &str) -> Result<HashMap<String, String>> {
 
     let args: HashMap<String, String> = lines
         .iter()
-        .flat_map(|line| match re.captures(line) {
-            None => None,
-            Some(captures) => {
-                let key = captures[1].to_string();
-                let value = captures[2].to_string();
-                Some((key, value))
-            }
+        .filter_map(|line| {
+            let captures = re.captures(line)?;
+            let key = captures[1].to_string();
+            let value = captures[2].to_string();
+            Some((key, value))
         })
         .collect();
 

--- a/src/ui/vc.rs
+++ b/src/ui/vc.rs
@@ -751,19 +751,16 @@ impl<'a> ViewController<'a> {
             // This is an option of a result of a key... Let's pop error cases first.
             let next_key = reader.keys().next();
 
-            if next_key.is_none() {
+            let Some(next_key) = next_key else {
                 // Nothing in the buffer. Wait for a bit...
                 std::thread::sleep(std::time::Duration::from_millis(25));
                 continue;
-            }
+            };
 
-            let key_res = next_key.unwrap();
-            if let Err(err) = key_res {
-                // Termion not being able to read from stdin is an unrecoverable error.
-                panic!("{}", err);
-            }
+            // Termion not being able to read from stdin is an unrecoverable error.
+            let key = next_key.unwrap_or_else(|err| panic!("{err}"));
 
-            match key_res.unwrap() {
+            match key {
                 event::Key::Esc => {
                     break;
                 }
@@ -860,7 +857,7 @@ impl<'a> ViewController<'a> {
                         .lookup_trie
                         .get_node(&typed_hint.chars().collect::<Vec<char>>());
 
-                    if node.is_none() {
+                    let Some(node) = node else {
                         if self.multi_select.enabled {
                             // In multi-select, don't exit on mistype
                             typed_hint.clear();
@@ -869,9 +866,7 @@ impl<'a> ViewController<'a> {
                         }
                         // A key outside the alphabet was entered.
                         return Event::Exit;
-                    }
-
-                    let node = node.unwrap();
+                    };
                     if node.is_leaf() {
                         let span_index = node.value().expect(
                             "By construction, the Lookup Trie should have a value for each leaf.",


### PR DESCRIPTION
Bump MSRV from 1.88 to 1.95 following the Rust 1.95.0 release (2026-04-16).

Updates Cargo.toml rust-version, CI matrix in large-scope.yml, and
documentation badges/requirements in README.md and INSTALLATION.md.

Also modernizes a few idioms that were available since earlier Rust versions
but hadn't been adopted: replaces `is_none()`/`unwrap()` sequences with
`let-else`, flattens a nested `match` on `Option` into `let-else`, switches
`flat_map` with manual `match` to `filter_map` with `?`, and replaces a
two-step error check with `unwrap_or_else`.