### PR TITLE
ci(renovate): switch to daily schedule

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,12 +1,12 @@
 # Runs Renovate to check for dependency updates.
-# Triggers weekly on Friday afternoons, or manually via workflow_dispatch.
+# Triggers daily at 19:00 UTC, or manually via workflow_dispatch.
 
 name: Renovate
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 16 * * 5' # every Friday at 16:00 UTC
+    - cron: '0 19 * * *' # daily at 19:00 UTC
 
 permissions: {}
 

--- a/renovate.json
+++ b/renovate.json
@@ -30,8 +30,5 @@
       ],
       "groupName": "minor updates"
     }
-  ],
-  "schedule": [
-    "before 9pm on friday"
   ]
 }


### PR DESCRIPTION
Run Renovate daily at 19:00 UTC instead of weekly on Fridays. The
Friday-only window was too infrequent — dependency updates sat for a
week before getting picked up.

Removed the `schedule` stanza from `renovate.json` so Renovate is no
longer restricted to a specific time window for opening PRs. The
workflow cron alone now controls when Renovate runs.