### PR TITLE
perf: compile static regexes once with LazyLock

### DIFF
--- a/src/config/basic.rs
+++ b/src/config/basic.rs
@@ -125,10 +125,10 @@ pub(crate) fn try_parse_chars(src: &str) -> Result<HintSurroundingsArg> {
         return Err(Error::ExpectedSurroundingPair);
     }
 
-    let chars: Vec<char> = src.chars().collect();
+    let mut chars = src.chars();
     Ok(HintSurroundingsArg {
-        open: chars[0],
-        close: chars[1],
+        open: chars.next().unwrap(),
+        close: chars.next().unwrap(),
     })
 }
 

--- a/src/textbuf/model.rs
+++ b/src/textbuf/model.rs
@@ -5,7 +5,7 @@ use sequence_trie::SequenceTrie;
 
 use super::alphabet::Alphabet;
 use super::raw_span::RawSpan;
-use super::regexes::{EXCLUDE_PATTERNS, NamedPattern, PATTERNS};
+use super::regexes::{EXCLUDE_REGEXES, NamedPattern, PATTERN_REGEXES};
 use super::span::Span;
 
 /// Holds data for the `Ui`.
@@ -67,12 +67,7 @@ fn find_raw_spans<'a>(
     custom_patterns: &'a [String],
     use_all_patterns: bool,
 ) -> Vec<RawSpan<'a>> {
-    let exclude_regexes = EXCLUDE_PATTERNS
-        .iter()
-        .map(|&(name, pattern)| (name, Regex::new(pattern).unwrap()))
-        .collect::<Vec<_>>();
-
-    let custom_regexes = custom_patterns
+    let custom_regexes: Vec<(&str, Regex)> = custom_patterns
         .iter()
         .map(|pattern| {
             (
@@ -80,21 +75,26 @@ fn find_raw_spans<'a>(
                 Regex::new(pattern).expect("Invalid custom regexp"),
             )
         })
-        .collect::<Vec<_>>();
+        .collect();
 
-    let regexes = if use_all_patterns {
-        PATTERNS
-            .iter()
-            .map(|&(name, pattern)| (name, Regex::new(pattern).unwrap()))
-            .collect::<Vec<(&str, regex::Regex)>>()
-    } else {
+    let named_regexes: Vec<(&str, Regex)> = if !use_all_patterns {
         named_patterns
             .iter()
             .map(|NamedPattern(name, pattern)| (name.as_str(), Regex::new(pattern).unwrap()))
-            .collect::<Vec<(&str, regex::Regex)>>()
+            .collect()
+    } else {
+        Vec::new()
     };
 
-    let all_regexes = [exclude_regexes, custom_regexes, regexes].concat();
+    // Collect references to all regexes: static (pre-compiled) + dynamic (per-call).
+    let mut all_regexes: Vec<(&str, &Regex)> = Vec::new();
+    all_regexes.extend(EXCLUDE_REGEXES.iter().map(|(n, r)| (*n, r)));
+    all_regexes.extend(custom_regexes.iter().map(|(n, r)| (*n, r)));
+    if use_all_patterns {
+        all_regexes.extend(PATTERN_REGEXES.iter().map(|(n, r)| (*n, r)));
+    } else {
+        all_regexes.extend(named_regexes.iter().map(|(n, r)| (*n, r)));
+    }
 
     let mut raw_spans = Vec::new();
 

--- a/src/textbuf/regexes.rs
+++ b/src/textbuf/regexes.rs
@@ -2,10 +2,30 @@
 //!
 //! All patterns must have one capture group. The first group is used.
 
+use std::sync::LazyLock;
+
+use regex::Regex;
+
 use crate::{Error, Result};
 
 pub(super) const EXCLUDE_PATTERNS: [(&str, &str); 1] =
     [("ansi_colors", r"[[:cntrl:]]\[([0-9]{1,2};)?([0-9]{1,2})?m")];
+
+/// Pre-compiled exclude regexes, built once on first access.
+pub(super) static EXCLUDE_REGEXES: LazyLock<Vec<(&str, Regex)>> = LazyLock::new(|| {
+    EXCLUDE_PATTERNS
+        .iter()
+        .map(|&(name, pattern)| (name, Regex::new(pattern).unwrap()))
+        .collect()
+});
+
+/// Pre-compiled pattern regexes, built once on first access.
+pub(super) static PATTERN_REGEXES: LazyLock<Vec<(&str, Regex)>> = LazyLock::new(|| {
+    PATTERNS
+        .iter()
+        .map(|&(name, pattern)| (name, Regex::new(pattern).unwrap()))
+        .collect()
+});
 
 /// Holds all the regex patterns that are currently supported.
 ///


### PR DESCRIPTION
`find_raw_spans` recompiled all 21 PATTERNS and the EXCLUDE_PATTERNS
regexes on every invocation — that's 22 calls to `Regex::new` each time
the user triggers a capture. Regex compilation involves parsing the
pattern, building an NFA, and compiling a DFA, which is orders of
magnitude more expensive than the actual matching.

Introduce two `LazyLock<Vec<(&str, Regex)>>` statics that compile once
on first access and are borrowed thereafter. Dynamic regexes (custom
patterns, named pattern subsets) are still compiled per-call since they
depend on user input.

Also simplifies `try_parse_chars` to iterate directly instead of
collecting into a Vec just to index two elements.