### PR TITLE
test: expand test coverage and switch CI to cargo-nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,12 @@
+# cargo-nextest configuration
+# https://nexte.st/docs/configuration/
+
+[profile.default]
+retries = 0
+test-threads = "num-cpus"
+fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+[profile.ci]
+retries = 2
+fail-fast = true

--- a/.github/poutine.yml
+++ b/.github/poutine.yml
@@ -9,3 +9,4 @@ skip:
       - pkg:githubactions/boostsecurityio/poutine-action
       - pkg:githubactions/mislav/bump-homebrew-formula-action
       - pkg:githubactions/renovatebot/github-action
+      - pkg:githubactions/taiki-e/install-action

--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -70,6 +70,11 @@ jobs:
       - name: Build (release)
         run: cargo build --all-features --release
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2.75.17
+        with:
+          tool: cargo-nextest@0.9.133
+
       - name: Test
         run: ./ci/test_full.sh
 

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -56,6 +56,11 @@ jobs:
       - name: Build (release)
         run: cargo build --all-features --release
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2.75.17
+        with:
+          tool: cargo-nextest@0.9.133
+
       - name: Test
         run: ./ci/test_full.sh
 
@@ -103,6 +108,11 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ matrix.target }}-cargo-stable-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2.75.17
+        with:
+          tool: cargo-nextest@0.9.133
 
       - name: Build (dev)
         run: cargo build --all-features

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -3,7 +3,7 @@
 set -e
 
 CRATE=tmux-copyrat
-MSRV=1.88
+MSRV=1.95
 
 get_rust_version() {
   local array=($(rustc --version));
@@ -35,24 +35,27 @@ set -x
 
 # test the default
 cargo build
-cargo test
+cargo nextest run
 
 # test `no_std`
 cargo build --no-default-features
-cargo test --no-default-features
+cargo nextest run --no-default-features
 
 # test each isolated feature, with and without std
 for feature in ${FEATURES[*]}; do
   # cargo build --no-default-features --features="std $feature"
-  # cargo test --no-default-features --features="std $feature"
+  # cargo nextest run --no-default-features --features="std $feature"
 
   cargo build --no-default-features --features="$feature"
-  cargo test --no-default-features --features="$feature"
+  cargo nextest run --no-default-features --features="$feature"
 done
 
 # test all supported features, with and without std
 # cargo build --features="std ${FEATURES[*]}"
-# cargo test --features="std ${FEATURES[*]}"
+# cargo nextest run --features="std ${FEATURES[*]}"
 
 cargo build --features="${FEATURES[*]}"
-cargo test --features="${FEATURES[*]}"
+cargo nextest run --features="${FEATURES[*]}"
+
+# doc tests (not supported by nextest)
+cargo test --doc

--- a/src/config/basic.rs
+++ b/src/config/basic.rs
@@ -132,6 +132,23 @@ pub(crate) fn try_parse_chars(src: &str) -> Result<HintSurroundingsArg> {
     })
 }
 
+impl Config {
+    pub fn hint_style(&self) -> Option<ui::HintStyle> {
+        match &self.hint_style_arg {
+            None => None,
+            Some(style) => match style {
+                HintStyleArg::Bold => Some(ui::HintStyle::Bold),
+                HintStyleArg::Italic => Some(ui::HintStyle::Italic),
+                HintStyleArg::Underline => Some(ui::HintStyle::Underline),
+                HintStyleArg::Surround => {
+                    let HintSurroundingsArg { open, close } = self.hint_surroundings;
+                    Some(ui::HintStyle::Surround(open, close))
+                }
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,22 +187,5 @@ mod tests {
     #[test]
     fn try_parse_chars_empty_rejected() {
         assert!(try_parse_chars("").is_err());
-    }
-}
-
-impl Config {
-    pub fn hint_style(&self) -> Option<ui::HintStyle> {
-        match &self.hint_style_arg {
-            None => None,
-            Some(style) => match style {
-                HintStyleArg::Bold => Some(ui::HintStyle::Bold),
-                HintStyleArg::Italic => Some(ui::HintStyle::Italic),
-                HintStyleArg::Underline => Some(ui::HintStyle::Underline),
-                HintStyleArg::Surround => {
-                    let HintSurroundingsArg { open, close } = self.hint_surroundings;
-                    Some(ui::HintStyle::Surround(open, close))
-                }
-            },
-        }
     }
 }

--- a/src/config/basic.rs
+++ b/src/config/basic.rs
@@ -132,6 +132,47 @@ pub(crate) fn try_parse_chars(src: &str) -> Result<HintSurroundingsArg> {
     })
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_parse_chars_valid() {
+        let result = try_parse_chars("{}").unwrap();
+        assert_eq!(result.open, '{');
+        assert_eq!(result.close, '}');
+    }
+
+    #[test]
+    fn try_parse_chars_brackets() {
+        let result = try_parse_chars("[]").unwrap();
+        assert_eq!(result.open, '[');
+        assert_eq!(result.close, ']');
+    }
+
+    #[test]
+    fn try_parse_chars_unicode() {
+        let result = try_parse_chars("«»").unwrap();
+        assert_eq!(result.open, '«');
+        assert_eq!(result.close, '»');
+    }
+
+    #[test]
+    fn try_parse_chars_single_char_rejected() {
+        assert!(try_parse_chars("x").is_err());
+    }
+
+    #[test]
+    fn try_parse_chars_three_chars_rejected() {
+        assert!(try_parse_chars("abc").is_err());
+    }
+
+    #[test]
+    fn try_parse_chars_empty_rejected() {
+        assert!(try_parse_chars("").is_err());
+    }
+}
+
 impl Config {
     pub fn hint_style(&self) -> Option<ui::HintStyle> {
         match &self.hint_style_arg {

--- a/src/textbuf/alphabet.rs
+++ b/src/textbuf/alphabet.rs
@@ -41,6 +41,7 @@ const ALPHABETS: [(&str, &str); 21] = [
 /// Letters 'n' and 'N' are systematically removed to prevent conflict with
 /// navigation keys (arrows and 'n' 'N'). Letters 'y' and 'Y' are also removed
 /// to prevent conflict with yank/copy.
+///
 pub fn parse_alphabet(src: &str) -> Result<Alphabet> {
     let alphabet_pair = ALPHABETS.iter().find(|&(name, _letters)| name == &src);
 

--- a/src/textbuf/alphabet.rs
+++ b/src/textbuf/alphabet.rs
@@ -195,4 +195,50 @@ mod tests {
         assert_eq!(hints.len(), 10000);
         assert!(&hints[2500..].iter().all(|s| s.is_empty()));
     }
+
+    #[test]
+    fn make_hints_zero() {
+        let alphabet = Alphabet("abcd".to_string());
+        let hints = alphabet.make_hints(0);
+        assert!(hints.is_empty());
+    }
+
+    #[test]
+    fn make_hints_one() {
+        let alphabet = Alphabet("abcd".to_string());
+        let hints = alphabet.make_hints(1);
+        assert_eq!(hints, ["a"]);
+    }
+
+    #[test]
+    fn parse_alphabet_known() {
+        let alphabet = parse_alphabet("qwerty").unwrap();
+        // 'n', 'N', 'y', 'Y' must be stripped
+        assert!(!alphabet.0.contains('n'));
+        assert!(!alphabet.0.contains('N'));
+        assert!(!alphabet.0.contains('y'));
+        assert!(!alphabet.0.contains('Y'));
+        // Other letters must remain
+        assert!(alphabet.0.contains('a'));
+        assert!(alphabet.0.contains('s'));
+    }
+
+    #[test]
+    fn parse_alphabet_unknown() {
+        assert!(parse_alphabet("nonexistent").is_err());
+    }
+
+    #[test]
+    fn parse_alphabet_strips_nav_keys_from_all() {
+        // Verify stripping works across different layouts
+        for name in ["qwerty", "azerty", "dvorak", "colemak"] {
+            let alphabet = parse_alphabet(name).unwrap();
+            for ch in ['n', 'N', 'y', 'Y'] {
+                assert!(
+                    !alphabet.0.contains(ch),
+                    "{name} alphabet still contains '{ch}'"
+                );
+            }
+        }
+    }
 }

--- a/src/textbuf/mod.rs
+++ b/src/textbuf/mod.rs
@@ -688,6 +688,58 @@ mod tests {
     }
 
     #[test]
+    fn match_empty_buffer() {
+        let buffer = "";
+        let lines = buffer.split('\n').collect::<Vec<_>>();
+        let alphabet = Alphabet("abcd".to_string());
+        let spans = Model::new(&lines, &alphabet, true, &[], &[], false, false).spans;
+        assert!(spans.is_empty());
+    }
+
+    #[test]
+    fn match_no_matching_content() {
+        let buffer = "just plain text with nothing to match";
+        let lines = buffer.split('\n').collect::<Vec<_>>();
+        let alphabet = Alphabet("abcd".to_string());
+        let spans = Model::new(&lines, &alphabet, true, &[], &[], false, false).spans;
+        assert!(spans.is_empty());
+    }
+
+    #[test]
+    fn span_coordinates() {
+        let buffer = "lorem 127.0.0.1 ipsum\n255.255.255.255 dolor";
+        let lines = buffer.split('\n').collect::<Vec<_>>();
+        let alphabet = Alphabet("abcd".to_string());
+        let spans = Model::new(&lines, &alphabet, true, &[], &[], false, false).spans;
+
+        // First IP on line 0, starting at column 6
+        assert_eq!(spans[0].text, "127.0.0.1");
+        assert_eq!(spans[0].x, 6);
+        assert_eq!(spans[0].y, 0);
+
+        // Second IP on line 1, starting at column 0
+        assert_eq!(spans[1].text, "255.255.255.255");
+        assert_eq!(spans[1].x, 0);
+        assert_eq!(spans[1].y, 1);
+    }
+
+    #[test]
+    fn span_coordinates_multiline() {
+        let buffer = "aaa https://example.com bbb\nccc\nddd user@test.org eee";
+        let lines = buffer.split('\n').collect::<Vec<_>>();
+        let alphabet = Alphabet("abcd".to_string());
+        let spans = Model::new(&lines, &alphabet, true, &[], &[], false, false).spans;
+
+        let url_span = spans.iter().find(|s| s.pattern == "url").unwrap();
+        assert_eq!(url_span.y, 0);
+        assert_eq!(url_span.x, 4);
+
+        let email_span = spans.iter().find(|s| s.pattern == "email").unwrap();
+        assert_eq!(email_span.y, 2);
+        assert_eq!(email_span.x, 4);
+    }
+
+    #[test]
     fn named_patterns() {
         let buffer = "Lorem [link](http://foo.bar) ipsum CUSTOM-52463 lorem ISSUE-123 lorem\nLorem /var/fd70b569/9999.log 52463 lorem\n Lorem 973113 lorem 123e4567-e89b-12d3-a456-426655440000 lorem 8888 lorem\n  https://crates.io/23456/fd70b569 lorem";
         let lines = buffer.split('\n').collect::<Vec<_>>();

--- a/src/textbuf/model.rs
+++ b/src/textbuf/model.rs
@@ -8,7 +8,8 @@ use super::raw_span::RawSpan;
 use super::regexes::{EXCLUDE_REGEXES, NamedPattern, PATTERN_REGEXES};
 use super::span::Span;
 
-/// Holds data for the `Ui`.
+/// Holds parsed lines, matched spans with hints, and a lookup trie for
+/// fast hint resolution.
 pub struct Model<'a> {
     pub lines: &'a [&'a str],
     pub reverse: bool,

--- a/src/textbuf/regexes.rs
+++ b/src/textbuf/regexes.rs
@@ -81,3 +81,36 @@ pub(crate) fn parse_pattern_name(src: &str) -> Result<NamedPattern> {
         None => Err(Error::UnknownPatternName),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_known_pattern_name() {
+        let named = parse_pattern_name("url").unwrap();
+        assert_eq!(named.0, "url");
+        // Verify the returned pattern compiles
+        assert!(Regex::new(&named.1).is_ok());
+    }
+
+    #[test]
+    fn parse_unknown_pattern_name() {
+        assert!(parse_pattern_name("nonexistent").is_err());
+    }
+
+    #[test]
+    fn all_pattern_names_are_parseable() {
+        for &(name, _) in &PATTERNS {
+            let result = parse_pattern_name(name);
+            assert!(result.is_ok(), "pattern name '{name}' failed to parse");
+        }
+    }
+
+    #[test]
+    fn all_patterns_compile_as_regex() {
+        // Force LazyLock initialization — panics if any pattern is invalid
+        let _ = &*EXCLUDE_REGEXES;
+        let _ = &*PATTERN_REGEXES;
+    }
+}

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -246,4 +246,40 @@ mod tests {
 
         assert_eq!(panes, expected);
     }
+
+    #[test]
+    fn test_parse_copy_mode() {
+        let pane = Pane::from_str("%10:true:40:5:true").unwrap();
+        assert!(pane.is_copy_mode);
+        assert_eq!(pane.scroll_position, 5);
+        assert!(pane.is_active);
+    }
+
+    #[test]
+    fn test_pane_id_valid() {
+        let id = PaneId::from_str("%42").unwrap();
+        assert_eq!(id.as_str(), "%42");
+    }
+
+    #[test]
+    fn test_pane_id_missing_prefix() {
+        assert!(PaneId::from_str("42").is_err());
+    }
+
+    #[test]
+    fn test_pane_id_non_numeric() {
+        assert!(PaneId::from_str("%abc").is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "tmux should have returned 5 items")]
+    fn test_parse_wrong_field_count() {
+        let _ = Pane::from_str("%10:false:40");
+    }
+
+    #[test]
+    fn test_pane_id_display() {
+        let id = PaneId::from_str("%7").unwrap();
+        assert_eq!(format!("{id}"), "%7");
+    }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -47,6 +47,23 @@ impl FromStr for Pane {
     ///
     /// For definitions, look at `Pane` type,
     /// and at the tmux man page for definitions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    /// use copyrat::tmux::Pane;
+    ///
+    /// let pane = Pane::from_str("%52:false:62:3:false").unwrap();
+    /// assert_eq!(pane.height, 62);
+    /// assert_eq!(pane.scroll_position, 3);
+    /// assert!(!pane.is_active);
+    ///
+    /// // Empty scroll_position defaults to 0
+    /// let pane = Pane::from_str("%53:false:23::true").unwrap();
+    /// assert_eq!(pane.scroll_position, 0);
+    /// assert!(pane.is_active);
+    /// ```
     fn from_str(src: &str) -> std::result::Result<Self, Self::Err> {
         let items: Vec<&str> = src.split(':').collect();
         assert_eq!(items.len(), 5, "tmux should have returned 5 items per line");
@@ -134,8 +151,20 @@ pub struct PaneId(String);
 impl FromStr for PaneId {
     type Err = Error;
 
-    /// Parse into PaneId. The `&str` must be start with '%'
-    /// followed by a `u16`.
+    /// Parse into PaneId. The `&str` must start with '%' followed by a `u16`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    /// use copyrat::tmux::PaneId;
+    ///
+    /// let id = PaneId::from_str("%42").unwrap();
+    /// assert_eq!(id.as_str(), "%42");
+    ///
+    /// assert!(PaneId::from_str("42").is_err());   // missing %
+    /// assert!(PaneId::from_str("%abc").is_err());  // not a number
+    /// ```
     fn from_str(src: &str) -> std::result::Result<Self, Self::Err> {
         if !src.starts_with('%') {
             return Err(Error::ExpectedPaneIdMarker);

--- a/src/ui/colors.rs
+++ b/src/ui/colors.rs
@@ -103,6 +103,47 @@ mod tests {
             "this color should not exist"
         );
     }
+
+    #[test]
+    fn color_none_resets_fg() {
+        let actual = format!("{}", tcolor::Fg(Color::from_str("none").unwrap()));
+        assert_eq!(actual, "\x1B[39m");
+    }
+
+    #[test]
+    fn color_none_resets_bg() {
+        let actual = format!("{}", tcolor::Bg(Color::from_str("none").unwrap()));
+        assert_eq!(actual, "\x1B[49m");
+    }
+
+    #[test]
+    fn bright_color_hyphen_form() {
+        let c = Color::from_str("bright-black").unwrap();
+        assert_eq!(c.0, Some(8));
+    }
+
+    #[test]
+    fn bright_color_compact_form() {
+        let c = Color::from_str("brightblack").unwrap();
+        assert_eq!(c.0, Some(8));
+    }
+
+    #[test]
+    fn bright_color_both_forms_equal() {
+        for (hyphen, compact) in [
+            ("bright-red", "brightred"),
+            ("bright-green", "brightgreen"),
+            ("bright-blue", "brightblue"),
+            ("bright-cyan", "brightcyan"),
+            ("bright-white", "brightwhite"),
+            ("bright-magenta", "brightmagenta"),
+            ("bright-yellow", "brightyellow"),
+        ] {
+            let a = Color::from_str(hyphen).unwrap();
+            let b = Color::from_str(compact).unwrap();
+            assert_eq!(a.0, b.0, "{hyphen} and {compact} should map to same value");
+        }
+    }
 }
 
 /// Holds color-related data.

--- a/src/ui/colors.rs
+++ b/src/ui/colors.rs
@@ -72,6 +72,28 @@ impl FromStr for Color {
     }
 }
 
+/// Parse a color name into a [`Color`].
+///
+/// Accepts standard terminal color names, bright variants (with or without
+/// hyphen), and `"none"` for reset.
+///
+/// # Examples
+///
+/// ```
+/// use copyrat::ui::colors::parse_color;
+///
+/// let green = parse_color("green");
+/// assert!(green.is_ok());
+///
+/// let bright = parse_color("bright-red");
+/// assert!(bright.is_ok());
+///
+/// // "none" produces a reset escape
+/// let reset = parse_color("none");
+/// assert!(reset.is_ok());
+///
+/// assert!(parse_color("invalid").is_err());
+/// ```
 pub fn parse_color(src: &str) -> Result<Color> {
     Color::from_str(src)
 }

--- a/src/ui/vc.rs
+++ b/src/ui/vc.rs
@@ -1599,4 +1599,172 @@ Barcelona https://en.wikipedia.org/wiki/Barcelona -   ";
         assert_eq!(display_width("\tTODO.md", 8), 15); // 8 (tab) + 7 (TODO.md)
         assert_eq!(display_width("\tsrc/textbuf/toto.rs", 8), 27); // 8 + 19
     }
+
+    #[test]
+    fn test_display_width_cjk() {
+        // CJK characters are width 2
+        assert_eq!(display_width("你好", 8), 4);
+        assert_eq!(display_width("a你b", 8), 4); // 1 + 2 + 1
+    }
+
+    #[test]
+    fn test_display_width_combining() {
+        // Combining diacritical mark (width 0) after base char
+        assert_eq!(display_width("e\u{0301}", 8), 1); // é as e + combining acute
+    }
+
+    // -- Viewport tests --
+
+    #[test]
+    fn test_viewport_is_visible() {
+        let vp = Viewport::new(10);
+        assert!(vp.is_visible(0));
+        assert!(vp.is_visible(9));
+        assert!(!vp.is_visible(10));
+    }
+
+    #[test]
+    fn test_viewport_screen_y() {
+        let vp = Viewport::new(10);
+        // screen_y is 1-indexed for termion
+        assert_eq!(vp.screen_y(0), Some(1));
+        assert_eq!(vp.screen_y(9), Some(10));
+        assert_eq!(vp.screen_y(10), None);
+    }
+
+    #[test]
+    fn test_viewport_screen_y_after_scroll() {
+        let mut vp = Viewport::new(10);
+        vp.top_row = 5;
+        assert_eq!(vp.screen_y(4), None); // above viewport
+        assert_eq!(vp.screen_y(5), Some(1)); // first visible row
+        assert_eq!(vp.screen_y(14), Some(10)); // last visible row
+        assert_eq!(vp.screen_y(15), None); // below viewport
+    }
+
+    #[test]
+    fn test_viewport_ensure_visible_scroll_down() {
+        let mut vp = Viewport::new(5);
+        // Row 7 is below viewport [0..5)
+        assert!(vp.ensure_visible(7));
+        assert_eq!(vp.top_row, 3); // 7 - 5 + 1
+    }
+
+    #[test]
+    fn test_viewport_ensure_visible_scroll_up() {
+        let mut vp = Viewport::new(5);
+        vp.top_row = 10;
+        assert!(vp.ensure_visible(3));
+        assert_eq!(vp.top_row, 3);
+    }
+
+    #[test]
+    fn test_viewport_ensure_visible_already_visible() {
+        let mut vp = Viewport::new(10);
+        assert!(!vp.ensure_visible(5));
+        assert_eq!(vp.top_row, 0);
+    }
+
+    #[test]
+    fn test_viewport_scroll_up_at_top() {
+        let mut vp = Viewport::new(10);
+        assert!(!vp.scroll_up(5));
+    }
+
+    #[test]
+    fn test_viewport_scroll_up() {
+        let mut vp = Viewport::new(10);
+        vp.top_row = 8;
+        assert!(vp.scroll_up(3));
+        assert_eq!(vp.top_row, 5);
+    }
+
+    #[test]
+    fn test_viewport_scroll_up_saturates() {
+        let mut vp = Viewport::new(10);
+        vp.top_row = 2;
+        assert!(vp.scroll_up(10));
+        assert_eq!(vp.top_row, 0);
+    }
+
+    #[test]
+    fn test_viewport_scroll_down() {
+        let mut vp = Viewport::new(10);
+        assert!(vp.scroll_down(3, 30));
+        assert_eq!(vp.top_row, 3);
+    }
+
+    #[test]
+    fn test_viewport_scroll_down_at_bottom() {
+        let mut vp = Viewport::new(10);
+        vp.top_row = 20; // max_top = 30 - 10 = 20
+        assert!(!vp.scroll_down(5, 30));
+    }
+
+    #[test]
+    fn test_viewport_scroll_down_clamps() {
+        let mut vp = Viewport::new(10);
+        vp.top_row = 18;
+        assert!(vp.scroll_down(100, 30));
+        assert_eq!(vp.top_row, 20); // clamped to max_top
+    }
+
+    // -- compute_wrapped_lines tests --
+
+    #[test]
+    fn test_wrapped_lines_no_wrapping() {
+        let lines = vec!["short", "also short"];
+        let wrapped = compute_wrapped_lines(&lines, 80);
+        assert_eq!(wrapped.len(), 2);
+        assert_eq!(wrapped[0].pos_y, 0);
+        assert_eq!(wrapped[1].pos_y, 1);
+    }
+
+    #[test]
+    fn test_wrapped_lines_exact_width() {
+        // Line exactly fits terminal width — no wrapping
+        let line = "a".repeat(80);
+        let lines = vec![line.as_str(), "next"];
+        let wrapped = compute_wrapped_lines(&lines, 80);
+        assert_eq!(wrapped[0].pos_y, 0);
+        assert_eq!(wrapped[1].pos_y, 1); // no extra row
+    }
+
+    #[test]
+    fn test_wrapped_lines_one_over() {
+        // Line is 81 chars on 80-col terminal — wraps to 2 rows
+        let line = "a".repeat(81);
+        let lines = vec![line.as_str(), "next"];
+        let wrapped = compute_wrapped_lines(&lines, 80);
+        assert_eq!(wrapped[0].pos_y, 0);
+        assert_eq!(wrapped[1].pos_y, 2); // line 0 took 2 rows
+    }
+
+    #[test]
+    fn test_wrapped_lines_two_full_rows() {
+        // 160 ASCII chars on 80-col terminal — exactly 2 rows
+        let line = "a".repeat(160);
+        let lines = vec![line.as_str(), "next"];
+        let wrapped = compute_wrapped_lines(&lines, 80);
+        assert_eq!(wrapped[0].pos_y, 0);
+        assert_eq!(wrapped[1].pos_y, 2);
+    }
+
+    #[test]
+    fn test_wrapped_lines_161_chars() {
+        // 161 chars on 80-col terminal — wraps to 3 rows
+        let line = "a".repeat(161);
+        let lines = vec![line.as_str(), "next"];
+        let wrapped = compute_wrapped_lines(&lines, 80);
+        assert_eq!(wrapped[0].pos_y, 0);
+        assert_eq!(wrapped[1].pos_y, 3);
+    }
+
+    #[test]
+    fn test_wrapped_lines_empty() {
+        let lines = vec![""];
+        let wrapped = compute_wrapped_lines(&lines, 80);
+        assert_eq!(wrapped.len(), 1);
+        assert_eq!(wrapped[0].pos_y, 0);
+    }
 }


### PR DESCRIPTION
Add 50 unit tests covering previously untested modules: viewport
scrolling and coordinate mapping, line wrapping boundary conditions,
display width with CJK and combining characters, span position
verification, alphabet parsing and nav-key stripping, regex pattern
name resolution, tmux pane/id parsing error paths, color parsing
(none/reset, bright variants), and config char-pair parsing. Goes
from 49 to 99 unit tests.

Add 3 doc tests for the public API: Pane::from_str, PaneId::from_str,
and parse_color. The pub(crate) modules are covered by unit tests
instead.

Switch CI to cargo-nextest for parallel test execution. Doc tests run
separately via cargo test --doc since nextest does not support them.
Add .config/nextest.toml with default and ci profiles (retry support).