### PR TITLE
Fix for-loop quoting and drop unused Windows release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   prepare-artifacts:
     name: Prepare release artifacts
-    runs-on: '${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
@@ -35,11 +35,6 @@ jobs:
             rust: stable
             suffix: ''
             archive_ext: tar.xz
-            # - os: windows-latest
-            #   target: x86_64-pc-windows-msvc
-            #   rust: stable
-            #   suffix: .exe
-            #   archive_ext: zip
     steps:
       - name: Rust install
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -72,17 +67,6 @@ jobs:
         run: |
           cp "target/${TARGET}/release/${REPO_NAME}" .
           zip -A "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
-
-      - name: Compress to zip (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
-        env:
-          REPO_NAME: ${{ github.event.repository.name }}
-          TARGET: ${{ matrix.target }}
-          ARCHIVE_EXT: ${{ matrix.archive_ext }}
-          SUFFIX: ${{ matrix.suffix }}
-        run: |
-          Copy-Item "target/${env:TARGET}/release/${env:REPO_NAME}${env:SUFFIX}" .
-          Compress-Archive "${env:REPO_NAME}${env:SUFFIX}" "${env:REPO_NAME}-${env:TARGET}.${env:ARCHIVE_EXT}"
 
       - name: Compress to tar.xz (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -42,7 +42,7 @@ cargo build --no-default-features
 cargo nextest run --no-default-features
 
 # test each isolated feature, with and without std
-for feature in ${FEATURES[*]}; do
+for feature in "${FEATURES[@]}"; do
   # cargo build --no-default-features --features="std $feature"
   # cargo nextest run --no-default-features --features="std $feature"
 


### PR DESCRIPTION
Fix shell quoting in `ci/test_full.sh` to use `"${FEATURES[@]}"` instead of `${FEATURES[*]}`, preventing word-splitting issues when feature names contain spaces.

Remove the commented-out Windows matrix entry and the associated `Compress to zip (Windows)` step from the release workflow — this project doesn't ship Windows binaries, so the dead code was just noise. Also drop unnecessary quotes around the `runs-on` value.