### PR TITLE
CI and Renovate maintenance

### DIFF
--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -28,34 +28,38 @@ if ! check_version $MSRV ; then
 fi
 
 FEATURES=()
-# check_version 1.85 && FEATURES+=(libm)
 echo "Testing supported features: ${FEATURES[*]}"
+
+NEXTEST_PROFILE=""
+if [ -n "$CI" ]; then
+  NEXTEST_PROFILE="--profile ci"
+fi
 
 set -x
 
 # test the default
 cargo build
-cargo nextest run
+cargo nextest run $NEXTEST_PROFILE
 
 # test `no_std`
 cargo build --no-default-features
-cargo nextest run --no-default-features
+cargo nextest run $NEXTEST_PROFILE --no-default-features
 
 # test each isolated feature, with and without std
 for feature in "${FEATURES[@]}"; do
   # cargo build --no-default-features --features="std $feature"
-  # cargo nextest run --no-default-features --features="std $feature"
+  # cargo nextest run $NEXTEST_PROFILE --no-default-features --features="std $feature"
 
   cargo build --no-default-features --features="$feature"
-  cargo nextest run --no-default-features --features="$feature"
+  cargo nextest run $NEXTEST_PROFILE --no-default-features --features="$feature"
 done
 
 # test all supported features, with and without std
 # cargo build --features="std ${FEATURES[*]}"
-# cargo nextest run --features="std ${FEATURES[*]}"
+# cargo nextest run $NEXTEST_PROFILE --features="std ${FEATURES[*]}"
 
 cargo build --features="${FEATURES[*]}"
-cargo nextest run --features="${FEATURES[*]}"
+cargo nextest run $NEXTEST_PROFILE --features="${FEATURES[*]}"
 
 # doc tests (not supported by nextest)
 cargo test --doc

--- a/renovate.json
+++ b/renovate.json
@@ -21,14 +21,16 @@
     {
       "description": "Group all patch updates into one PR",
       "matchUpdateTypes": "patch",
-      "groupName": "patch updates"
+      "groupName": "patch updates",
+      "automerge": true
     },
     {
       "description": "Group all minor updates into one PR",
       "matchUpdateTypes": [
         "minor"
       ],
-      "groupName": "minor updates"
+      "groupName": "minor updates",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
The nextest ci profile (retries, fail-fast) was defined in .config/nextest.toml
but never actually selected. test_full.sh now detects the $CI env var and passes
--profile ci automatically. Also dropped a stale check_version guard that was
never adapted for this crate.

On the Renovate side, patch and minor grouped PRs now automerge after CI passes.
Major updates still require manual review.