### PR TITLE
ci: align workflows with github-actions-playbook conventions

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,2 @@
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+-P ubuntu-24.04-arm=catthehacker/ubuntu:act-latest

--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -1,4 +1,7 @@
 # Reusable workflow: dependency audit via cargo-deny and cargo-pants.
+#
+# Local (standalone):
+#   act workflow_call -W .github/workflows/_cargo-audit.yml
 
 name: Cargo Audit
 
@@ -14,7 +17,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Rust install
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
@@ -24,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache crates from crates.io
+      - name: Cache crates
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         continue-on-error: false
         with:
@@ -36,7 +39,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-stable-audit-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: cargo deny check
+      - name: Security – cargo deny
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -47,7 +50,7 @@ jobs:
           mv cargo-deny ~/.cargo/bin/
           cargo deny check
 
-      - name: cargo pants
+      - name: Security – cargo pants
         run: |
           cargo install --locked cargo-pants || true
           cargo pants

--- a/.github/workflows/_ci-security.yml
+++ b/.github/workflows/_ci-security.yml
@@ -1,4 +1,7 @@
 # Reusable workflow: CI/CD supply chain security audits.
+#
+# Local (standalone):
+#   act workflow_call -W .github/workflows/_ci-security.yml
 
 name: CI Security
 
@@ -21,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run zizmor
+      - name: Scan workflows (zizmor)
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
 
   poutine:
@@ -37,7 +40,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run poutine
+      - name: Scan workflows (poutine)
         uses: boostsecurityio/poutine-action@e240ebd3eff8b2db5a8e5f6b28f58739d7db2247 # v1.1.4
 
       - name: Upload SARIF

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,16 +1,24 @@
-# Test pre-releases on a larger scope (platforms & versions) to avoid bad surprises.
+# Compatibility testing: multi-version and multi-platform matrix.
+#
+# Local:
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-versions
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-other-platforms
 
-name: Large scope
+name: 'CI: Compatibility Matrix'
 on:
   push:
     branches:
-      - staging
+      - 'compat/*'
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-versions:
-    name: Tests on Linux
+    name: ubuntu-latest (${{ matrix.rust }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,7 +27,7 @@ jobs:
         rust: [1.95.0, beta, nightly]
 
     steps:
-      - name: Rust install
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
@@ -30,7 +38,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache crates from crates.io
+      - name: Cache crates
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         continue-on-error: false
         with:
@@ -42,11 +50,11 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Quality - cargo fmt
+      - name: Quality – cargo fmt
         run: |
           cargo fmt --all -- --check
 
-      - name: Quality - cargo clippy
+      - name: Quality – cargo clippy
         run: |
           cargo clippy --all-targets --all-features -- -D warnings
 
@@ -65,7 +73,7 @@ jobs:
         run: ./ci/test_full.sh
 
   test-other-platforms:
-    name: Tests on
+    name: ${{ matrix.os }} (stable)
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -85,7 +93,7 @@ jobs:
             type: unix
             toolchain: stable
     steps:
-      - name: Rust install
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -97,7 +105,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache crates from crates.io
+      - name: Cache crates
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         continue-on-error: false
         with:

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -1,6 +1,10 @@
-# Any commit on main & PRs
+# Any commit on main & PRs.
+#
+# Local:
+#   act push -W .github/workflows/ci-essentials.yml -j test
+#   act push -W .github/workflows/ci-essentials.yml -j changes
 
-name: Essentials
+name: 'CI: Essentials'
 on:
   push:
     branches:
@@ -9,9 +13,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
-    name: Quality checks & tests
+    name: Build & test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,7 +27,7 @@ jobs:
       matrix:
         rust: [stable]
     steps:
-      - name: Rust install
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
@@ -33,7 +41,7 @@ jobs:
           # fetch-depth: ${{ github.event.pull_request.commits }}
           persist-credentials: false
 
-      - name: Cache crates from crates.io
+      - name: Cache crates
         if: github.event_name == 'pull_request'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         continue-on-error: false
@@ -46,15 +54,15 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Quality - cargo fmt
+      - name: Quality – cargo fmt
         run: |
           cargo fmt --all -- --check
 
-      - name: Quality - cargo clippy
+      - name: Quality – cargo clippy
         run: |
           cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Quality - convco check
+      - name: Quality – convco check
         run: |
           git show-ref
           curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
@@ -87,10 +95,12 @@ jobs:
       cargo_lock: ${{ steps.filter.outputs.cargo_lock }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - id: filter
+      - name: Filter changed paths
+        id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
@@ -109,7 +119,7 @@ jobs:
     if: needs.changes.outputs.cargo_lock == 'true'
     permissions:
       contents: read
-    uses: ./.github/workflows/cargo-audit.yml
+    uses: ./.github/workflows/_cargo-audit.yml
 
   ci-security:
     needs: changes
@@ -118,4 +128,4 @@ jobs:
       security-events: write
       contents: read
       actions: read
-    uses: ./.github/workflows/ci-security.yml
+    uses: ./.github/workflows/_ci-security.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,10 @@
+# Tag-triggered release: build multi-platform binaries and publish.
+#
+# Local:
+#   act push -W .github/workflows/release.yml -j prepare-artifacts
+#   act push -W .github/workflows/release.yml -j release
+#   act push -W .github/workflows/release.yml -j homebrew
+
 name: Release
 on:
   push:
@@ -6,9 +13,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   prepare-artifacts:
-    name: Prepare release artifacts
+    name: Build artifacts
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -36,7 +47,7 @@ jobs:
             suffix: ''
             archive_ext: tar.xz
     steps:
-      - name: Rust install
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
@@ -53,13 +64,13 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Build Release
+      - name: Build (release)
         env:
           TARGET: ${{ matrix.target }}
         run: cargo build --release --target "${TARGET}"
 
-      - name: Compress to zip (macOS)
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel' }}
+      - name: Package – compress (zip)
+        if: ${{ matrix.archive_ext == 'zip' }}
         env:
           REPO_NAME: ${{ github.event.repository.name }}
           TARGET: ${{ matrix.target }}
@@ -68,8 +79,8 @@ jobs:
           cp "target/${TARGET}/release/${REPO_NAME}" .
           zip -A "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
 
-      - name: Compress to tar.xz (Linux)
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
+      - name: Package – compress (tar.xz)
+        if: ${{ matrix.archive_ext == 'tar.xz' }}
         env:
           REPO_NAME: ${{ github.event.repository.name }}
           TARGET: ${{ matrix.target }}
@@ -78,7 +89,7 @@ jobs:
           cp "target/${TARGET}/release/${REPO_NAME}" .
           tar Jcf "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
 
-      - name: List files
+      - name: Package – list files
         env:
           TARGET: ${{ matrix.target }}
         run: |
@@ -86,7 +97,7 @@ jobs:
           ls -alF "target/${TARGET}/release/"
         shell: bash
 
-      - name: Upload artifacts
+      - name: Upload – archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
@@ -94,7 +105,7 @@ jobs:
           retention-days: 1
 
   release:
-    name: Create a GitHub Release
+    name: Publish release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -115,32 +126,36 @@ jobs:
         run: |
           echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-      - name: Download convco
+      - name: Install convco
         run: |
           git show-ref
           curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
           unzip convco-ubuntu.zip
           chmod +x convco
 
-      - name: Use convco to create the changelog
+      - name: Generate changelog
         run: |
           ./convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
           rm convco convco-ubuntu.zip
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – archive (x86_64-unknown-linux-musl)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.event.repository.name }}-x86_64-unknown-linux-musl.tar.xz
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – archive (aarch64-unknown-linux-musl)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.event.repository.name }}-aarch64-unknown-linux-musl.tar.xz
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – archive (aarch64-apple-darwin)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.event.repository.name }}-aarch64-apple-darwin.zip
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Download – archive (x86_64-apple-darwin)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.event.repository.name }}-x86_64-apple-darwin.zip
 
-      - name: Create GitHub Release
+      - name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
@@ -150,7 +165,7 @@ jobs:
             --notes-file CHANGELOG.md \
             ./*.zip ./*.tar.xz
 
-      - name: Attest build provenance
+      - name: Attest provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: '*.zip,*.tar.xz'

--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -1,7 +1,9 @@
-# Runs Renovate to check for dependency updates.
-# Triggers weekly at 19:00 UTC, or manually via workflow_dispatch.
+# Scheduled Renovate run via GitHub App token.
+#
+# Local:
+#   act workflow_dispatch -W .github/workflows/schedule-renovate.yml
 
-name: Renovate
+name: 'Schedule: Renovate'
 
 on:
   workflow_dispatch:
@@ -10,9 +12,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   renovate:
-    name: Renovate
+    name: Run Renovate
     runs-on: ubuntu-latest
     environment: renovate
     permissions:

--- a/.github/workflows/schedule-supply-chain.yml
+++ b/.github/workflows/schedule-supply-chain.yml
@@ -1,6 +1,9 @@
 # Scheduled supply chain audits: dependency vulnerabilities and CI security.
+#
+# Local:
+#   act workflow_dispatch -W .github/workflows/schedule-supply-chain.yml
 
-name: Supply Chain Audit
+name: 'Schedule: Supply Chain Audit'
 
 on:
   workflow_dispatch:
@@ -10,15 +13,19 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   cargo-audit:
     permissions:
       contents: read
-    uses: ./.github/workflows/cargo-audit.yml
+    uses: ./.github/workflows/_cargo-audit.yml
 
   ci-security:
     permissions:
       security-events: write
       contents: read
       actions: read
-    uses: ./.github/workflows/ci-security.yml
+    uses: ./.github/workflows/_ci-security.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,7 +4,7 @@ rules:
   # which is intentional for multi-version matrix builds.
   superfluous-actions:
     ignore:
-      - cargo-audit.yml
-      - essentials.yml
-      - large-scope.yml
+      - _cargo-audit.yml
+      - ci-essentials.yml
+      - ci-compatibility-matrix.yml
       - release.yml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tmux-copyrat
 
-[![build status](https://github.com/graelo/tmux-copyrat/actions/workflows/essentials.yml/badge.svg)](https://github.com/graelo/tmux-copyrat/actions)
+[![build status](https://github.com/graelo/tmux-copyrat/actions/workflows/ci-essentials.yml/badge.svg)](https://github.com/graelo/tmux-copyrat/actions)
 [![rustc 1.95+](https://img.shields.io/badge/rustc-1.95+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![edition 2024](https://img.shields.io/badge/edition-2024-blue.svg)](https://doc.rust-lang.org/edition-guide/rust-2024/index.html)
 [![crate](https://img.shields.io/crates/v/copyrat.svg)](https://crates.io/crates/copyrat)


### PR DESCRIPTION
Bring the workflows in line with the playbook in
../github-actions-playbook/: rename files to the trigger-prefixed
scheme (_cargo-audit, ci-essentials, ci-compatibility-matrix,
release, schedule-renovate, schedule-supply-chain), tidy job and
step names (`Build & test`, `Quality – cargo …` with en-dash,
`Security – cargo deny/pants`, `Package – compress (zip|tar.xz)`,
etc.), and add the per-trigger-family concurrency groups that were
missing.

The one behaviour-affecting change: the compatibility matrix now
triggers on `compat/*` instead of pushes to `staging`, matching the
playbook's pattern.

Local `act` simulation is now first-class: each workflow has a
header showing the exact `act` invocations, and a project-local
`.actrc` maps `ubuntu-latest`/`ubuntu-24.04-arm` to a Docker image.

Also refreshes the stale `superfluous-actions` ignore list in
`.github/zizmor.yml` (the previous filenames silently no-op'd) and
the README build badge URL.

After merge, the `main` branch ruleset's required checks need to be
updated in the web UI from `Essentials / test`/`Essentials / changes`
to `CI: Essentials / Build & test`/`CI: Essentials / Detect changes`,
otherwise PRs sit in "Waiting for status to be reported".