### PR TITLE
ci(renovate): enable debug logs to diagnose repository-changed aborts

### DIFF
--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -43,5 +43,6 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
+          LOG_LEVEL: debug
         with:
           configurationFile: renovate.json


### PR DESCRIPTION
## Summary

- The last three Renovate runs (one scheduled, two manual) aborted ~18 s in with `Repository has changed during renovation - aborting`, before any PR creation or dashboard refresh.
- The `info`-level log line does not identify which SHA or resource Renovate considers changed, so we cannot diagnose the root cause from existing logs.
- This patch sets `LOG_LEVEL: debug` on the Renovate step so the next run surfaces the specific mutation. To be reverted (or kept, depending on appetite for diagnostics-by-default) once the cause is identified.

## Test plan

- [ ] Merge.
- [ ] Manually re-dispatch `Schedule: Renovate`.
- [ ] Inspect the run log for the line identifying which SHA/resource changed (commonly: base-branch SHA, managed-branch SHA, or dashboard-issue body).