### PR TITLE
ci(renovate): set automergeStrategy to merge-commit and drop debug logs

### DIFF
--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -43,6 +43,5 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
-          LOG_LEVEL: debug
         with:
           configurationFile: renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     "enabled": true
   },
   "platformAutomerge": true,
+  "automergeStrategy": "merge-commit",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

- Set `automergeStrategy: "merge-commit"` in `renovate.json`. Renovate's GitHub-native automerge was failing with `Merge method squash merging is not allowed on this repository` because the ruleset on `main` permits only `[merge, rebase]` and Renovate's default `auto` strategy sends `mergeMethod=SQUASH`. `main`'s first-parent history is exclusively `Merge pull request #N from …` commits, so `merge-commit` matches existing style.
- Revert the temporary `LOG_LEVEL: debug` from `schedule-renovate.yml` (added in #67). The underlying cause of the `repository-changed` aborts — the `graelo-ci-bot` GitHub App lacked `Commit statuses: write` — has been resolved at the App level, and the existing run on `main` (after the permission grant) successfully created PRs #68 and #69.

## Test plan

- [ ] Merge.
- [ ] Verify the next scheduled or manually dispatched Renovate run still creates/updates PRs cleanly with `info`-level logs.
- [ ] On the next merge-eligible PR (after `minimumReleaseAge` clears and required reviews are in), confirm the GraphQL `enablePullRequestAutoMerge` mutation succeeds (no `UNPROCESSABLE` errors in the run log) and the resulting merge commit on `main` has the expected `Merge pull request #N from …` shape.