### PR TITLE
ci: align CI and release workflows with playbook

### DIFF
--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -77,6 +77,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -80,15 +80,21 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.target }}
     strategy:
       matrix:
         include:
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
             type: unix
             toolchain: stable
           - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
+            type: unix
+            toolchain: stable
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
             type: unix
             toolchain: stable
           - os: macos-latest
@@ -102,6 +108,10 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           targets: ${{ matrix.target }}
           components: rustfmt, clippy
+
+      - name: Install musl-tools (Linux)
+        if: contains(matrix.target, '-musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-          # fetch-depth: ${{ github.event.pull_request.commits }}
           persist-credentials: false
 
       - name: Cache crates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,18 +27,19 @@ jobs:
       run:
         shell: bash
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-latest
             target: aarch64-apple-darwin
             rust: stable
             suffix: ''
-            archive_ext: zip
+            archive_ext: tar.xz
           - os: macos-15-intel
             target: x86_64-apple-darwin
             rust: stable
             suffix: ''
-            archive_ext: zip
+            archive_ext: tar.xz
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             rust: stable
@@ -72,25 +73,16 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: cargo build --release --target "${TARGET}"
 
-      - name: Package – compress (zip)
-        if: ${{ matrix.archive_ext == 'zip' }}
-        env:
-          REPO_NAME: ${{ github.event.repository.name }}
-          TARGET: ${{ matrix.target }}
-          ARCHIVE_EXT: ${{ matrix.archive_ext }}
-        run: |
-          cp "target/${TARGET}/release/${REPO_NAME}" .
-          zip -A "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
-
       - name: Package – compress (tar.xz)
-        if: ${{ matrix.archive_ext == 'tar.xz' }}
         env:
           REPO_NAME: ${{ github.event.repository.name }}
           TARGET: ${{ matrix.target }}
           ARCHIVE_EXT: ${{ matrix.archive_ext }}
         run: |
+          set -euo pipefail
           cp "target/${TARGET}/release/${REPO_NAME}" .
-          tar Jcf "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" "${REPO_NAME}"
+          tar Jcf "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" \
+            "${REPO_NAME}" README.md LICENSE
 
       - name: Package – list files
         env:
@@ -110,6 +102,7 @@ jobs:
   release:
     name: Publish release
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       id-token: write
@@ -152,11 +145,11 @@ jobs:
       - name: Download – archive (aarch64-apple-darwin)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ github.event.repository.name }}-aarch64-apple-darwin.zip
+          name: ${{ github.event.repository.name }}-aarch64-apple-darwin.tar.xz
       - name: Download – archive (x86_64-apple-darwin)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ github.event.repository.name }}-x86_64-apple-darwin.zip
+          name: ${{ github.event.repository.name }}-x86_64-apple-darwin.tar.xz
 
       - name: Create GitHub release
         env:
@@ -166,12 +159,12 @@ jobs:
           gh release create "${TAG_NAME}" \
             --title "${TAG_NAME}" \
             --notes-file CHANGELOG.md \
-            ./*.zip ./*.tar.xz
+            ./*.tar.xz
 
       - name: Attest provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: '*.zip,*.tar.xz'
+          subject-path: '*.tar.xz'
 
   homebrew:
     name: Bump Homebrew formula

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,13 @@ concurrency:
 
 jobs:
   prepare-artifacts:
-    name: Build artifacts
+    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         include:
@@ -193,7 +196,8 @@ jobs:
         run: |
           echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
-      - uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
+      - name: Bump Homebrew formula
+        uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
         if: '!contains(github.ref, ''-'')' # skip prereleases
         with:
           formula-name: tmux-copyrat

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,16 +73,18 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: cargo build --release --target "${TARGET}"
 
-      - name: Package – compress (tar.xz)
+      - name: Package – standalone + archive
         env:
           REPO_NAME: ${{ github.event.repository.name }}
           TARGET: ${{ matrix.target }}
           ARCHIVE_EXT: ${{ matrix.archive_ext }}
         run: |
           set -euo pipefail
+          cp "target/${TARGET}/release/${REPO_NAME}" "${REPO_NAME}-${TARGET}"
           cp "target/${TARGET}/release/${REPO_NAME}" .
           tar Jcf "${REPO_NAME}-${TARGET}.${ARCHIVE_EXT}" \
             "${REPO_NAME}" README.md LICENSE
+          rm "${REPO_NAME}"
 
       - name: Package – list files
         env:
@@ -90,7 +92,13 @@ jobs:
         run: |
           ls -alF .
           ls -alF "target/${TARGET}/release/"
-        shell: bash
+
+      - name: Upload – standalone
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ github.event.repository.name }}-${{ matrix.target }}
+          path: ${{ github.event.repository.name }}-${{ matrix.target }}
+          retention-days: 1
 
       - name: Upload – archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -134,6 +142,23 @@ jobs:
           ./convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
           rm convco convco-ubuntu.zip
 
+      - name: Download – standalone (x86_64-unknown-linux-musl)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ github.event.repository.name }}-x86_64-unknown-linux-musl
+      - name: Download – standalone (aarch64-unknown-linux-musl)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ github.event.repository.name }}-aarch64-unknown-linux-musl
+      - name: Download – standalone (aarch64-apple-darwin)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ github.event.repository.name }}-aarch64-apple-darwin
+      - name: Download – standalone (x86_64-apple-darwin)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ github.event.repository.name }}-x86_64-apple-darwin
+
       - name: Download – archive (x86_64-unknown-linux-musl)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -154,17 +179,27 @@ jobs:
       - name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_NAME: ${{ github.event.repository.name }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
           gh release create "${TAG_NAME}" \
             --title "${TAG_NAME}" \
             --notes-file CHANGELOG.md \
-            ./*.tar.xz
+            ./*.tar.xz \
+            ./"${REPO_NAME}"-aarch64-apple-darwin \
+            ./"${REPO_NAME}"-x86_64-apple-darwin \
+            ./"${REPO_NAME}"-aarch64-unknown-linux-musl \
+            ./"${REPO_NAME}"-x86_64-unknown-linux-musl
 
       - name: Attest provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: '*.tar.xz'
+          subject-path: |
+            *.tar.xz
+            ${{ github.event.repository.name }}-aarch64-apple-darwin
+            ${{ github.event.repository.name }}-x86_64-apple-darwin
+            ${{ github.event.repository.name }}-aarch64-unknown-linux-musl
+            ${{ github.event.repository.name }}-x86_64-unknown-linux-musl
 
   homebrew:
     name: Bump Homebrew formula

--- a/.github/workflows/schedule-supply-chain.yml
+++ b/.github/workflows/schedule-supply-chain.yml
@@ -8,8 +8,7 @@ name: 'Schedule: Supply Chain Audit'
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 16 * * 2' # Tuesday at 16:00 UTC
-    - cron: '0 16 * * 5' # Friday at 16:00 UTC
+    - cron: '0 16 * * 2,5' # Tuesday and Friday at 16:00 UTC
 
 permissions: {}
 

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -5,6 +5,6 @@
 set -ex
 
 ci=$(dirname $0)
-for version in 1.88.0 stable beta nightly; do
+for version in 1.95.0 stable beta nightly; do
     rustup run "$version" "$ci/test_full.sh"
 done

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -69,13 +69,12 @@ install() {
         x86_64|amd64) arch="x86_64" ;; arm64|aarch64) arch="aarch64" ;; *) die "Unsupported arch: $(uname -m). Install manually: ${RELEASES_URL}" ;;
     esac
 
-    # Build expected asset name
+    # Build expected standalone-binary asset name
     local asset
-    if [[ "$os" == "darwin" ]]; then
-        asset="${BINARY}-${arch}-apple-darwin.zip"
-    else
-        asset="${BINARY}-${arch}-unknown-linux-musl.tar.xz"
-    fi
+    case "$os" in
+        darwin) asset="${BINARY}-${arch}-apple-darwin" ;;
+        linux)  asset="${BINARY}-${arch}-unknown-linux-musl" ;;
+    esac
 
     # Get download URL from GitHub API
     local api_url="https://api.github.com/repos/${REPO}/releases/latest"
@@ -86,34 +85,9 @@ install() {
     url=$(echo "$release_info" | grep -o "\"browser_download_url\":[[:space:]]*\"[^\"]*${asset}\"" | sed 's/.*"\(http[^"]*\)".*/\1/')
     [[ -n "$url" ]] || die "No binary found for ${os}-${arch}. Install manually: ${RELEASES_URL}"
 
-    # Download and extract
+    # Download standalone binary directly to destination
     log "Downloading ${asset}..."
-    local tmp="${SCRIPT_DIR}/${asset}"
-    download "$url" "$tmp" || die "Download failed"
-
-    if [[ "$asset" == *.zip ]]; then
-        unzip -qo "$tmp" -d "$SCRIPT_DIR"
-    else
-        tar -xf "$tmp" -C "$SCRIPT_DIR"
-    fi
-    rm -f "$tmp"
-
-    # Find and move binary to expected location
-    local found=""
-    for candidate in "${SCRIPT_DIR}/${BINARY}" "${SCRIPT_DIR}/target/release/${BINARY}" "${SCRIPT_DIR}/release/${BINARY}"; do
-        [[ -f "$candidate" ]] && found="$candidate" && break
-    done
-    [[ -n "$found" ]] || die "Binary not found after extraction"
-
-    if [[ "$found" != "$BINARY_PATH" ]]; then
-        mv "$found" "$BINARY_PATH"
-        # Clean up leftover empty directories
-        local d; d=$(dirname "$found")
-        while [[ "$d" != "$SCRIPT_DIR" ]] && [[ -d "$d" ]]; do
-            rmdir "$d" 2>/dev/null || break
-            d=$(dirname "$d")
-        done
-    fi
+    download "$url" "$BINARY_PATH" || die "Download failed"
     chmod +x "$BINARY_PATH"
 
     # Record installed version

--- a/src/ui/vc.rs
+++ b/src/ui/vc.rs
@@ -447,7 +447,7 @@ impl<'a> ViewController<'a> {
             bg_color = color::Bg(*bg_color),
             fg_reset = color::Fg(color::Reset),
             bg_reset = color::Bg(color::Reset),
-            text = &text,
+            text = text,
         )
         .unwrap();
     }
@@ -1104,7 +1104,7 @@ path: /usr/local/bin/cargo";
                 bg = color::Bg(colors.focused_bg),
                 fg_reset = color::Fg(color::Reset),
                 bg_reset = color::Bg(color::Reset),
-                text = &text,
+                text = text,
             )
             .as_bytes()
         );
@@ -1141,7 +1141,7 @@ path: /usr/local/bin/cargo";
                 bg = color::Bg(colors.span_bg),
                 fg_reset = color::Fg(color::Reset),
                 bg_reset = color::Bg(color::Reset),
-                text = &text,
+                text = text,
             )
             .as_bytes()
         );
@@ -1178,7 +1178,7 @@ path: /usr/local/bin/cargo";
                 bg = color::Bg(colors.selected_bg),
                 fg_reset = color::Fg(color::Reset),
                 bg_reset = color::Bg(color::Reset),
-                text = &text,
+                text = text,
             )
             .as_bytes()
         );


### PR DESCRIPTION
Bring CI and release workflows in line with the github-actions-playbook,
covering naming/concurrency conventions, the compatibility matrix, and
release artifact shape.

Notable behavior changes:
- macOS release archives switch from .zip to .tar.xz so all targets share
  a format; archives now bundle README + LICENSE alongside the binary.
- Each target now also publishes a bare standalone binary
  (tmux-copyrat-<target>) — a stable URL pattern that auto-installers can
  consume directly.
- install-binary.sh fetches the standalone instead of extracting the
  archive: one download to the destination, then chmod +x. Also fixes a
  latent bug where it requested a .zip on macOS, which would have stopped
  resolving once the format flipped.
- The release job is now gated behind environment: release, matching the
  homebrew job.

CI-side: bash shell default on multi-platform jobs, fail-fast: false on
the release matrix, set -euo pipefail in the packaging step, Linux compat
rows on *-unknown-linux-musl with conditional musl-tools install, and
ci/rustup.sh bumped from 1.88.0 to 1.95.0 to match the declared MSRV.

The release-PR pattern (release-plz) and a cargo-publish step are
intentionally deferred to a follow-up.