### PR TITLE
ci: finish playbook conformance — attestation, --all-features, renovate

### DIFF
--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -56,13 +56,13 @@ jobs:
 
       - name: Quality – cargo clippy
         run: |
-          cargo clippy --all-targets --all-features -- -D warnings
+          cargo clippy --all-targets -- -D warnings
 
       - name: Build (dev)
-        run: cargo build --all-features
+        run: cargo build
 
       - name: Build (release)
-        run: cargo build --all-features --release
+        run: cargo build --release
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
@@ -136,10 +136,10 @@ jobs:
           tool: cargo-nextest@0.9.133
 
       - name: Build (dev)
-        run: cargo build --all-features
+        run: cargo build
 
       - name: Build (release)
-        run: cargo build --all-features --release
+        run: cargo build --release
 
       - name: Test
         run: ./ci/test_full.sh

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Quality – cargo clippy
         run: |
-          cargo clippy --all-targets --all-features -- -D warnings
+          cargo clippy --all-targets -- -D warnings
 
       - name: Quality – convco check
         run: |
@@ -72,10 +72,10 @@ jobs:
           rm convco
 
       - name: Build (dev)
-        run: cargo build --all-features
+        run: cargo build
 
       - name: Build (release)
-        run: cargo build --all-features --release
+        run: cargo build --release
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     defaults:
       run:
         shell: bash
@@ -93,6 +95,13 @@ jobs:
           ls -alF .
           ls -alF "target/${TARGET}/release/"
 
+      - name: Attest provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            ${{ github.event.repository.name }}-${{ matrix.target }}
+            ${{ github.event.repository.name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
+
       - name: Upload – standalone
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -113,8 +122,6 @@ jobs:
     environment: release
     permissions:
       contents: write
-      id-token: write
-      attestations: write
     needs:
       - prepare-artifacts
     steps:
@@ -190,16 +197,6 @@ jobs:
             ./"${REPO_NAME}"-x86_64-apple-darwin \
             ./"${REPO_NAME}"-aarch64-unknown-linux-musl \
             ./"${REPO_NAME}"-x86_64-unknown-linux-musl
-
-      - name: Attest provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: |
-            *.tar.xz
-            ${{ github.event.repository.name }}-aarch64-apple-darwin
-            ${{ github.event.repository.name }}-x86_64-apple-darwin
-            ${{ github.event.repository.name }}-aarch64-unknown-linux-musl
-            ${{ github.event.repository.name }}-x86_64-unknown-linux-musl
 
   homebrew:
     name: Bump Homebrew formula

--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,9 @@
     },
     {
       "description": "Group all patch updates into one PR",
-      "matchUpdateTypes": "patch",
+      "matchUpdateTypes": [
+        "patch"
+      ],
       "groupName": "patch updates",
       "automerge": true
     },


### PR DESCRIPTION
Follow-up to #71. Covers the remaining playbook gaps besides release-plz
and crates.io publishing.

Build-provenance attestation moves from the centralized release job into
each prepare-artifacts matrix entry, so every target attests its binary
and archive on the runner that built them. id-token: write /
attestations: write follow the work to that job.

The clippy and cargo build steps drop --all-features. The crate has no
[features] table and no cfg(feature) gates, so the flag was a no-op that
muddied intent. ci/test_full.sh keeps its feature-matrix scaffolding for
reference.

renovate.json switches matchUpdateTypes for the patch rule to the array
form, matching the sibling minor rule and the reference config.