### PR TITLE
ci: apply playbook matrix-job conventions

### DIFF
--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,8 +1,8 @@
 # Compatibility testing: multi-version and multi-platform matrix.
 #
 # Local:
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-versions
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-platforms
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-rust-versions
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-platforms
 
 name: 'CI: Compatibility Matrix'
 on:
@@ -17,8 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-all-versions:
-    name: ubuntu-latest (${{ matrix.rust }})
+  test-rust-versions:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -75,8 +74,7 @@ jobs:
       - name: Test
         run: ./ci/test_full.sh
 
-  test-all-platforms:
-    name: ${{ matrix.target }}
+  test-platforms:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -23,14 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      matrix:
-        rust: [stable]
     steps:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Checkout
@@ -51,7 +48,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-hash-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Quality – cargo fmt
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ concurrency:
 
 jobs:
   prepare-artifacts:
-    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read


### PR DESCRIPTION
Align matrix jobs across the workflow files with the github-actions-playbook
naming rules so that GitHub renders each variant as `<job-key>
(<matrix-values>)` and the job key stays visible in CI logs and check names.

In ci-compatibility-matrix.yml, `test-all-versions` becomes `test-rust-versions`
and `test-all-platforms` becomes `test-platforms` — each one named for the
dimension it varies — and the custom `name:` templates are dropped. In
ci-essentials.yml the single-value `rust: [stable]` matrix is removed and
`stable` is inlined in the toolchain step and the cache key. In release.yml the
`name: ${{ matrix.target }}` is dropped from `prepare-artifacts`, whose key is
already canonical.

No `needs:` references pointed at the old keys, so nothing else needed updating.
The `act` invocations in the header comment of ci-compatibility-matrix.yml were
updated to the new job keys.