### PR TITLE
ci: switch homebrew bump to brew CLI and hoist vars to env

### DIFF
--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -52,5 +52,5 @@ jobs:
 
       - name: Security – cargo pants
         run: |
-          cargo install --locked cargo-pants || true
+          cargo install --locked cargo-pants || command -v cargo-pants
           cargo pants

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,8 +144,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
+          IS_PRERELEASE: ${{ contains(github.ref, '-') }}
         run: |
           gh release create "${TAG_NAME}" \
+            --prerelease="${IS_PRERELEASE}" \
             --title "${TAG_NAME}" \
             --notes-file CHANGELOG.md \
             ./artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,13 @@ jobs:
       contents: read
     needs:
       - release
+    if: ${{ !contains(github.ref, '-') }} # skip prereleases (-rc, -alpha, -beta, ...)
+    env:
+      TAP_REPO: graelo/homebrew-tap
+      FORMULA_NAME: tmux-copyrat
+      BOT_NAME: 'graelo-ci-bot[bot]'
+      BOT_USER_ID: '274240725'
+      REPO_URL: ${{ github.server_url }}/${{ github.repository }}
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -170,23 +177,34 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - name: Extract version
-        id: extract-version
+      - name: Configure Homebrew, git, and gh for the bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
+          # Linuxbrew is preinstalled on ubuntu-latest; put it on PATH for later steps.
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> "${GITHUB_PATH}"
+
+          # Tap our formula so `brew bump-formula-pr` can locate it by name.
+          brew tap "${TAP_REPO}"
+
+          # Configure git to push with the app token, and set the bot identity
+          # so the commit is attributed to ${BOT_NAME}.
+          gh auth setup-git
+          git config --global user.name  "${BOT_NAME}"
+          git config --global user.email "${BOT_USER_ID}+${BOT_NAME}@users.noreply.github.com"
 
       - name: Bump Homebrew formula
-        uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
-        if: '!contains(github.ref, ''-'')' # skip prereleases
-        with:
-          formula-name: tmux-copyrat
-          homebrew-tap: graelo/homebrew-tap
-          push-to: graelo/homebrew-tap
-          create-pullrequest: true
-          download-url: https://github.com/graelo/tmux-copyrat/archive/refs/tags/${{ steps.extract-version.outputs.tag-name }}.tar.gz
-          commit-message: |
-            {{formulaName}} {{version}}
-
-            Created by https://github.com/mislav/bump-homebrew-formula-action
         env:
-          COMMITTER_TOKEN: ${{ steps.app-token.outputs.token }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HOMEBREW_NO_AUTO_UPDATE: '1'
+          HOMEBREW_NO_ANALYTICS: '1'
+          HOMEBREW_NO_ENV_HINTS: '1'
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          brew bump-formula-pr \
+            --no-browse \
+            --no-fork \
+            --url="${REPO_URL}/archive/refs/tags/${TAG_NAME}.tar.gz" \
+            "${TAP_REPO}/${FORMULA_NAME}"


### PR DESCRIPTION
Apply two playbook updates to the release workflow.

**Homebrew bump via brew CLI.** Replace
mislav/bump-homebrew-formula-action with Homebrew's own
`brew bump-formula-pr`. The action was unmaintained and required a
poutine.yml suppression for an unverified creator — one fewer
third-party action in the supply chain. Tap the formula repo,
configure git with the app-token-backed credential helper, and run
brew directly. The bot identity (name + numeric user-id) is set
explicitly so commits attribute to graelo-ci-bot[bot] rather than a
generic "GitHub Actions" identity.

Per-project values (TAP_REPO, FORMULA_NAME, BOT_NAME, BOT_USER_ID)
are hoisted into the job-level env so the substitution points sit at
the top of the job. REPO_URL is derived from github.server_url +
github.repository, so the archive URL carries no hardcoded project
name.

**Prerelease flag.** Tags containing `-` (e.g. `v1.2.3-rc.1`) are now
marked as pre-releases on the GitHub Release via
`--prerelease="${IS_PRERELEASE}"`, where IS_PRERELEASE is the raw
`contains(github.ref, '-')` boolean. The flag is always present;
only the value toggles. Quoted expansion, no SC2086. The homebrew
job already skips on the same condition, so prereleases don't
pollute the tap.