### PR TITLE
chore(ci): switch Renovate automerge to squash

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     "enabled": true
   },
   "platformAutomerge": true,
-  "automergeStrategy": "merge-commit",
+  "automergeStrategy": "squash",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
Switch Renovate's automerge strategy from merge-commit to squash. Keeps the main branch history cleaner by squashing dependency updates into single commits instead of preserving merge commits.