### PR TITLE
fix(ci): update convco download URL for v0.7.0 release

### DIFF
--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -61,12 +61,12 @@ jobs:
         run: |
           git show-ref
           echo Commit message: "$(git log -1 --pretty=%B)"
-          curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
-          unzip convco-ubuntu.zip
-          chmod +x convco
-          ./convco --version
-          ./convco check -c .convco
-          rm convco
+          curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-x86_64-unknown-linux-musl.tar.gz
+          tar -xzf convco-x86_64-unknown-linux-musl.tar.gz
+          chmod +x convco-x86_64-unknown-linux-musl/convco
+          ./convco-x86_64-unknown-linux-musl/convco --version
+          ./convco-x86_64-unknown-linux-musl/convco check -c .convco
+          rm -rf convco-x86_64-unknown-linux-musl convco-x86_64-unknown-linux-musl.tar.gz
 
       - name: Build (dev)
         run: cargo build --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,14 +124,14 @@ jobs:
 
       - name: Install convco
         run: |
-          curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
-          unzip convco-ubuntu.zip
-          chmod +x convco
+          curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-x86_64-unknown-linux-musl.tar.gz
+          tar -xzf convco-x86_64-unknown-linux-musl.tar.gz
+          chmod +x convco-x86_64-unknown-linux-musl/convco
 
       - name: Generate changelog
         run: |
-          ./convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
-          rm convco convco-ubuntu.zip
+          ./convco-x86_64-unknown-linux-musl/convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
+          rm -rf convco-x86_64-unknown-linux-musl convco-x86_64-unknown-linux-musl.tar.gz
 
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
Fixes the CI failure caused by convco v0.7.0 no longer providing convco-ubuntu.zip.

Updates both CI workflows to download convco-x86_64-unknown-linux-musl.tar.gz and use tar extraction instead of unzip.