### PR TITLE
ci: replace manual convco install with taiki-e/install-action

### DIFF
--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -57,16 +57,17 @@ jobs:
         run: |
           cargo clippy --locked --all-targets -- -D warnings
 
+      - name: Install convco
+        uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
+        with:
+          tool: convco@0.7.0
+
       - name: Quality – convco check
         run: |
           git show-ref
           echo Commit message: "$(git log -1 --pretty=%B)"
-          curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-x86_64-unknown-linux-musl.tar.gz
-          tar -xzf convco-x86_64-unknown-linux-musl.tar.gz
-          chmod +x convco-x86_64-unknown-linux-musl/convco
-          ./convco-x86_64-unknown-linux-musl/convco --version
-          ./convco-x86_64-unknown-linux-musl/convco check -c .convco
-          rm -rf convco-x86_64-unknown-linux-musl convco-x86_64-unknown-linux-musl.tar.gz
+          convco --version
+          convco check -c .convco
 
       - name: Build (dev)
         run: cargo build --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,15 +123,13 @@ jobs:
           persist-credentials: false
 
       - name: Install convco
-        run: |
-          curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-x86_64-unknown-linux-musl.tar.gz
-          tar -xzf convco-x86_64-unknown-linux-musl.tar.gz
-          chmod +x convco-x86_64-unknown-linux-musl/convco
+        uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
+        with:
+          tool: convco@0.7.0
 
       - name: Generate changelog
         run: |
-          ./convco-x86_64-unknown-linux-musl/convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
-          rm -rf convco-x86_64-unknown-linux-musl convco-x86_64-unknown-linux-musl.tar.gz
+          convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
 
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
Replace the manual convco installation steps in CI workflows with taiki-e/install-action v2.85.0.

Both ci-essentials.yml and release.yml previously used curl/tar/chmod to download and extract convco from GitHub releases, followed by cleanup. Now they use the install-action with `tool: convco@0.7.0`, which handles download, extraction, and PATH setup automatically.

This removes ~10 lines of boilerplate per workflow and pins the action to a specific commit SHA for reproducibility.